### PR TITLE
Add esp-stub-lib library dependency and code style checker

### DIFF
--- a/.astyle-rules.yml
+++ b/.astyle-rules.yml
@@ -1,0 +1,10 @@
+---
+DEFAULT:
+  # These formatting options will be used by default.
+  options: "--style=otbs --attach-namespaces --attach-classes --indent=spaces=4 --convert-tabs --align-reference=name --keep-one-line-statements\
+    \ --pad-header --pad-oper --unpad-paren --max-continuation-indent=120"
+
+submodules:
+  check: false
+  include:
+    - "/esp-stub-lib/"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "esp-stub-lib"]
+	path = esp-stub-lib
+	url = https://github.com/espressif/esp-stub-lib

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,9 @@ repos:
     hooks:
       - id: conventional-precommit-linter
         stages: [commit-msg]
+
+  - repo: https://github.com/espressif/astyle_py.git
+    rev: v1.1.0
+    hooks:
+      - id: astyle_py
+        args: ['--astyle-version=3.4.7', '--rules=.astyle-rules.yml']


### PR DESCRIPTION
- Add submodule dependency for https://github.com/espressif/esp-stub-lib with the initial reference to the current master head.
- Add C/C++ style checker with the same style as used by https://github.com/espressif/esp-idf and https://github.com/espressif/esp-stub-lib.