### PR TITLE
feat: Add initial chip structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,8 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/src)
 
 set(ESP_TARGET ${TARGET_CHIP} CACHE INTERNAL "Pass TARGET_CHIP as ESP_TARGET")
 add_subdirectory(${CMAKE_SOURCE_DIR}/esp-stub-lib)
-target_link_libraries(${TARGET_NAME} PRIVATE esp-stub-lib)
+add_subdirectory(${CMAKE_SOURCE_DIR}/soc)
+target_link_libraries(${TARGET_NAME} PRIVATE esp-stub-lib soc)
 
 add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
     COMMAND ${CMAKE_SOURCE_DIR}/tools/elf2json.py ${CMAKE_BINARY_DIR}/${TARGET_NAME}${CMAKE_EXECUTABLE_SUFFIX_C} ${CMAKE_BINARY_DIR}/${TARGET_CHIP}.json

--- a/soc/CMakeLists.txt
+++ b/soc/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.28)
+
+add_library(soc STATIC)
+
+target_sources(soc PRIVATE
+    common/soc.c
+    common/watchdog_common.c
+)
+
+target_sources(soc PRIVATE targets/${TARGET_CHIP}.c)
+
+# Include directories
+target_include_directories(soc PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)

--- a/soc/common/soc.c
+++ b/soc/common/soc.c
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/*
+ * Single SoC info structure - chip-specific file provides this
+ * Chip selected at compile time
+ */
+extern const struct soc_info g_soc_info;
+
+const struct soc_info* soc_get_info(void)
+{
+    return &g_soc_info;
+}

--- a/soc/common/watchdog_common.c
+++ b/soc/common/watchdog_common.c
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include "soc.h"
+
+void disable_watchdogs(void)
+{
+    const struct watchdog *watchdog = soc_get_peripherals()->watchdog;
+    if (watchdog->wdt_disable) {
+        watchdog->wdt_disable();
+    }
+}
+
+void enable_watchdogs(void)
+{
+    const struct watchdog *watchdog = soc_get_peripherals()->watchdog;
+    if (watchdog->wdt_enable) {
+        watchdog->wdt_enable();
+    }
+}

--- a/soc/include/peripherals/usb_otg.h
+++ b/soc/include/peripherals/usb_otg.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* USB OTG peripheral structure */
+struct usb_otg {
+    uint32_t usb_otg_intr_map_reg;            /* USB OTG interrupt mapping */
+    uint32_t hp_sys_usbotg20_ctrl_reg;        /* USB OTG control register */
+    uint32_t usb_inum;                        /* USB interrupt number */
+    uint32_t clic_ext_intr_num_offset;        /* RISC-V CLIC interrupt offset */
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/soc/include/peripherals/watchdog.h
+++ b/soc/include/peripherals/watchdog.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Watchdog peripheral structure */
+struct watchdog {
+    /* Register offsets */
+    uint32_t option1_reg;
+    uint32_t wdtconfig0_reg;
+    uint32_t wdtwprotect_reg;
+    uint32_t swd_conf_reg;
+    uint32_t swd_wprotect_reg;
+    uint32_t cpu_per_conf_reg;
+    uint32_t sysclk_conf_reg;
+
+    /* Chip-specific values */
+    uint32_t swd_wkey;
+    uint32_t wdt_wkey;
+    uint32_t swd_auto_feed_en_bit;
+    uint32_t force_download_boot_bit;
+    uint32_t cpuperiod_sel_mask;
+    uint32_t cpuperiod_sel_shift;
+    uint32_t cpuperiod_max;
+    uint32_t soc_clk_sel_mask;
+    uint32_t soc_clk_sel_shift;
+    uint32_t soc_clk_max;
+
+    /* Function pointers for RTC-specific operations */
+    void (*wdt_disable)(void);
+    void (*wdt_enable)(void);
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/soc/include/soc.h
+++ b/soc/include/soc.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "peripherals/usb_otg.h"
+#include "peripherals/watchdog.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Essential SoC Capabilities for flasher stub */
+struct soc_capabilities {
+    bool is_riscv;              /* RISC-V architecture (affects interrupt handling) */
+};
+
+/* Essential peripherals for flasher stub */
+struct soc_peripherals {
+    const struct usb_otg *usb_otg;        /* USB-OTG communication */
+    const struct watchdog *watchdog;  /* Watchdog and power management */
+};
+
+/* Main SoC structure */
+struct soc_info {
+    const struct soc_capabilities *capabilities;
+    const struct soc_peripherals *peripherals;
+    uint8_t security_info_bytes;
+};
+
+const struct soc_info* soc_get_info(void);
+
+/* Convenience accessors */
+static inline const struct soc_capabilities* soc_get_capabilities(void)
+{
+    return soc_get_info()->capabilities;
+}
+
+static inline const struct soc_peripherals* soc_get_peripherals(void)
+{
+    return soc_get_info()->peripherals;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/soc/targets/esp32.c
+++ b/soc/targets/esp32.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32 capabilities */
+static const struct soc_capabilities esp32_capabilities = {
+    .is_riscv = false,
+};
+
+/* ESP32 USB-OTG peripheral */
+static const struct usb_otg esp32_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32 Watchdog peripheral */
+static const struct watchdog esp32_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32 peripherals structure */
+static const struct soc_peripherals esp32_peripherals = {
+    .usb_otg = &esp32_usb_otg,
+    .watchdog = &esp32_watchdog,
+};
+
+/* ESP32 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32_capabilities,
+    .peripherals = &esp32_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32c2.c
+++ b/soc/targets/esp32c2.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32C2 capabilities */
+static const struct soc_capabilities esp32c2_capabilities = {
+    .is_riscv = true,
+};
+
+/* ESP32C2 USB-OTG peripheral */
+static const struct usb_otg esp32c2_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32C2 Watchdog peripheral */
+static const struct watchdog esp32c2_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32C2 peripherals structure */
+static const struct soc_peripherals esp32c2_peripherals = {
+    .usb_otg = &esp32c2_usb_otg,
+    .watchdog = &esp32c2_watchdog,
+};
+
+/* ESP32C2 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32c2_capabilities,
+    .peripherals = &esp32c2_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32c3.c
+++ b/soc/targets/esp32c3.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32C3 capabilities */
+static const struct soc_capabilities esp32c3_capabilities = {
+    .is_riscv = true,
+};
+
+/* ESP32C3 USB-OTG peripheral */
+static const struct usb_otg esp32c3_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32C3 Watchdog peripheral */
+static const struct watchdog esp32c3_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32C3 peripherals structure */
+static const struct soc_peripherals esp32c3_peripherals = {
+    .usb_otg = &esp32c3_usb_otg,
+    .watchdog = &esp32c3_watchdog,
+};
+
+/* ESP32C3 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32c3_capabilities,
+    .peripherals = &esp32c3_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32c5.c
+++ b/soc/targets/esp32c5.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32C5 capabilities */
+static const struct soc_capabilities esp32c5_capabilities = {
+    .is_riscv = true,
+};
+
+/* ESP32C5 USB-OTG peripheral */
+static const struct usb_otg esp32c5_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32C5 Watchdog peripheral */
+static const struct watchdog esp32c5_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32C5 peripherals structure */
+static const struct soc_peripherals esp32c5_peripherals = {
+    .usb_otg = &esp32c5_usb_otg,
+    .watchdog = &esp32c5_watchdog,
+};
+
+/* ESP32C5 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32c5_capabilities,
+    .peripherals = &esp32c5_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32c6.c
+++ b/soc/targets/esp32c6.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32C6 capabilities */
+static const struct soc_capabilities esp32c6_capabilities = {
+    .is_riscv = true,
+};
+
+/* ESP32C6 USB-OTG peripheral */
+static const struct usb_otg esp32c6_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32C6 Watchdog peripheral */
+static const struct watchdog esp32c6_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32C6 peripherals structure */
+static const struct soc_peripherals esp32c6_peripherals = {
+    .usb_otg = &esp32c6_usb_otg,
+    .watchdog = &esp32c6_watchdog,
+};
+
+/* ESP32C6 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32c6_capabilities,
+    .peripherals = &esp32c6_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32c61.c
+++ b/soc/targets/esp32c61.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32C61 capabilities */
+static const struct soc_capabilities esp32c61_capabilities = {
+    .is_riscv = true,
+};
+
+/* ESP32C61 USB-OTG peripheral */
+static const struct usb_otg esp32c61_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32C61 Watchdog peripheral */
+static const struct watchdog esp32c61_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32C61 peripherals structure */
+static const struct soc_peripherals esp32c61_peripherals = {
+    .usb_otg = &esp32c61_usb_otg,
+    .watchdog = &esp32c61_watchdog,
+};
+
+/* ESP32C61 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32c61_capabilities,
+    .peripherals = &esp32c61_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32h2.c
+++ b/soc/targets/esp32h2.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32H2 capabilities */
+static const struct soc_capabilities esp32h2_capabilities = {
+    .is_riscv = true,
+};
+
+/* ESP32H2 USB-OTG peripheral */
+static const struct usb_otg esp32h2_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32H2 Watchdog peripheral */
+static const struct watchdog esp32h2_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32H2 peripherals structure */
+static const struct soc_peripherals esp32h2_peripherals = {
+    .usb_otg = &esp32h2_usb_otg,
+    .watchdog = &esp32h2_watchdog,
+};
+
+/* ESP32H2 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32h2_capabilities,
+    .peripherals = &esp32h2_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32p4.c
+++ b/soc/targets/esp32p4.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32P4 capabilities */
+static const struct soc_capabilities esp32p4_capabilities = {
+    .is_riscv = true,
+};
+
+/* ESP32P4 USB-OTG peripheral */
+static const struct usb_otg esp32p4_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32P4 Watchdog peripheral */
+static const struct watchdog esp32p4_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32P4 peripherals structure */
+static const struct soc_peripherals esp32p4_peripherals = {
+    .usb_otg = &esp32p4_usb_otg,
+    .watchdog = &esp32p4_watchdog,
+};
+
+/* ESP32P4 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32p4_capabilities,
+    .peripherals = &esp32p4_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32s2.c
+++ b/soc/targets/esp32s2.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32S2 capabilities */
+static const struct soc_capabilities esp32s2_capabilities = {
+    .is_riscv = false,
+};
+
+/* ESP32S2 USB-OTG peripheral */
+static const struct usb_otg esp32s2_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32S2 Watchdog peripheral */
+static const struct watchdog esp32s2_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32S2 peripherals structure */
+static const struct soc_peripherals esp32s2_peripherals = {
+    .usb_otg = &esp32s2_usb_otg,
+    .watchdog = &esp32s2_watchdog,
+};
+
+/* ESP32S2 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32s2_capabilities,
+    .peripherals = &esp32s2_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp32s3.c
+++ b/soc/targets/esp32s3.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP32S3 capabilities */
+static const struct soc_capabilities esp32s3_capabilities = {
+    .is_riscv = false,
+};
+
+/* ESP32S3 USB-OTG peripheral */
+static const struct usb_otg esp32s3_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP32S3 Watchdog peripheral */
+static const struct watchdog esp32s3_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP32S3 peripherals structure */
+static const struct soc_peripherals esp32s3_peripherals = {
+    .usb_otg = &esp32s3_usb_otg,
+    .watchdog = &esp32s3_watchdog,
+};
+
+/* ESP32S3 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp32s3_capabilities,
+    .peripherals = &esp32s3_peripherals,
+    .security_info_bytes = 0,
+};

--- a/soc/targets/esp8266.c
+++ b/soc/targets/esp8266.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stddef.h>
+#include "soc.h"
+
+/* ESP8266 capabilities */
+static const struct soc_capabilities esp8266_capabilities = {
+    .is_riscv = false,
+};
+
+/* ESP8266 USB-OTG peripheral */
+static const struct usb_otg esp8266_usb_otg = {
+    .usb_otg_intr_map_reg = 0,
+    .hp_sys_usbotg20_ctrl_reg = 0,
+    .usb_inum = 0,
+    .clic_ext_intr_num_offset = 0,
+};
+
+/* ESP8266 Watchdog peripheral */
+static const struct watchdog esp8266_watchdog = {
+    .option1_reg = 0,
+    .wdtconfig0_reg = 0,
+    .wdtwprotect_reg = 0,
+    .swd_conf_reg = 0,
+    .swd_wprotect_reg = 0,
+    .cpu_per_conf_reg = 0,
+    .sysclk_conf_reg = 0,
+    .swd_wkey = 0,
+    .wdt_wkey = 0,
+    .swd_auto_feed_en_bit = 0,
+    .force_download_boot_bit = 0,
+    .cpuperiod_sel_mask = 0,
+    .cpuperiod_sel_shift = 0,
+    .cpuperiod_max = 0,
+    .soc_clk_sel_mask = 0,
+    .soc_clk_sel_shift = 0,
+    .soc_clk_max = 0,
+    .wdt_disable = NULL,
+    .wdt_enable = NULL,
+};
+
+/* ESP8266 peripherals structure */
+static const struct soc_peripherals esp8266_peripherals = {
+    .usb_otg = &esp8266_usb_otg,
+    .watchdog = &esp8266_watchdog,
+};
+
+/* ESP8266 SoC info */
+const struct soc_info g_soc_info = {
+    .capabilities = &esp8266_capabilities,
+    .peripherals = &esp8266_peripherals,
+    .security_info_bytes = 0,
+};


### PR DESCRIPTION
## Description

This PR creates initial chip structure. It tries to utilize a bit more data driven structure than [esp-stub-lib](https://github.com/espressif/esp-stub-lib) as I believe there will not be big differences when using each peripheral, so if it is supported, common function can be used. Aim is to have as much common function as possible, but if it cannot be done, there can be per chip function in the structure.

I am open to suggestions, this was my first idea how this can be done compared to esp-stub-lib, I believe it is even a bit more comparable and better when it comes to avoiding #ifdefs, even though there has to be NULL checks for unsupported features.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [x ] All CI checks (GH Actions) pass.
- [x ] Documentation is updated as needed.
- [x ] Tests are updated or added as necessary.
- [x ] Code is well-commented, especially in complex areas.
- [x ] Git history is clean — commits are squashed to the minimum necessary.
