### PR TITLE
fix: sending error responses (align with esptool)

### DIFF
--- a/src/commands.h
+++ b/src/commands.h
@@ -39,31 +39,23 @@ extern "C" {
 #define ESP_RUN_USER_CODE       0xD3
 
 /**
- * @brief Response status - SUCCESS or FAIL
- * Should be max 0xFF to be compatible with protocol
+ * @brief ESP command response codes (16-bit)
+ * Wire format: big-endian (2 bytes, high byte first)
  */
-#define SUCCESS 0x00
-#define FAIL    0x01
-
-/**
- * @brief ESP command error codes
- * Used as the error_msg byte when status is FAIL
- * Should be max 0xFF to be compatible with protocol
- */
-#define NO_ERROR            0x00
-
-#define BAD_DATA_LEN        0xC0
-#define BAD_DATA_CHECKSUM   0xC1
-#define BAD_BLOCKSIZE       0xC2
-#define INVALID_COMMAND     0xC3
-#define FAILED_SPI_OP       0xC4
-#define FAILED_SPI_UNLOCK   0xC5
-#define NOT_IN_FLASH_MODE   0xC6
-#define INFLATE_ERROR       0xC7
-#define NOT_ENOUGH_DATA     0xC8
-#define TOO_MUCH_DATA       0xC9
-
-#define CMD_NOT_IMPLEMENTED 0xFF
+typedef enum {
+    RESPONSE_SUCCESS             = 0x0000,
+    RESPONSE_BAD_DATA_LEN        = 0xC000,
+    RESPONSE_BAD_DATA_CHECKSUM   = 0xC100,
+    RESPONSE_BAD_BLOCKSIZE       = 0xC200,
+    RESPONSE_INVALID_COMMAND     = 0xC300,
+    RESPONSE_FAILED_SPI_OP       = 0xC400,
+    RESPONSE_FAILED_SPI_UNLOCK   = 0xC500,
+    RESPONSE_NOT_IN_FLASH_MODE   = 0xC600,
+    RESPONSE_INFLATE_ERROR       = 0xC700,
+    RESPONSE_NOT_ENOUGH_DATA     = 0xC800,
+    RESPONSE_TOO_MUCH_DATA       = 0xC900,
+    RESPONSE_CMD_NOT_IMPLEMENTED = 0xFF00
+} esp_response_code_t;
 
 /**
  * @brief ESP command expected data sizes (in bytes)
@@ -88,15 +80,6 @@ extern "C" {
 #define READ_FLASH_SIZE         16
 #define ERASE_FLASH_SIZE        0
 #define ERASE_REGION_SIZE       8
-
-/**
- * @brief Combined response structure with status and error
- * Used to send response status and error code together
- */
-struct esp_response {
-    uint8_t status;     // response_status_t value (SUCCESS/FAIL)
-    uint8_t error;      // error_code_t value
-};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Make the sending of error responses to be compatible with the esptool. 

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
