### PR TITLE
feat(esp32s31): Implement support for the ESP32-S31 target

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,8 +16,8 @@ These are linked from the main `README.md`, which serves as the user guide.
 **Project Type**: Embedded C firmware with CMake build system
 **Languages**: C (firmware), Python (build tools, tests)
 **Size**: Small (~11 C source files, ~2000 lines main codebase)
-**Target Chips**: esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4-rev1, esp32p4, esp8266
-**Build Time**: ~0.5-1.5 seconds per chip, ~10-16 seconds for all chips built by build_all_chips.sh (13 chips)
+**Target Chips**: esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4-rev1, esp32p4, esp32s31, esp8266
+**Build Time**: ~0.5-1.5 seconds per chip, ~10-16 seconds for all chips built by build_all_chips.sh (14 chips)
 
 ## Critical Setup Steps (ALWAYS Follow This Order)
 
@@ -64,7 +64,7 @@ cd ..
 This downloads and extracts three toolchains (takes ~2-5 minutes):
 1. `xtensa-esp-elf-15.1.0_20250607` - For esp32, esp32s2, esp32s3 (~120MB download)
 2. `xtensa-lx106-elf-gcc8_4_0-esp-2020r3` - For esp8266 (~100MB download)
-3. `riscv32-esp-elf-15.1.0_20250607` - For esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4-rev1, esp32p4 (~255MB download)
+3. `riscv32-esp-elf-15.1.0_20250607` - For esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4-rev1, esp32p4, esp32s31 (~255MB download)
 
 **Note**: Network issues may cause partial downloads. If esp8266 toolchain fails, you can still build other chips.
 
@@ -119,7 +119,7 @@ source ./tools/export_toolchains.sh
 ./tools/build_all_chips.sh
 ```
 
-**Build Time**: ~10-15 seconds for all 13 chips (note: cmake defines 14 total targets, but build script excludes esp32h21)
+**Build Time**: ~10-15 seconds for all 14 chips (note: cmake defines 15 total targets, but build script excludes esp32h21)
 **Output**: Creates `build-{chip}/` directories for each chip with ELF and JSON files
 
 This script uses a **two-pass build** process:
@@ -288,7 +288,7 @@ The repository uses pre-commit.ci for automated PR checks. It runs all pre-commi
 - **Linker scripts**: Each chip has a specific linker script in `src/ld/{chip}.ld`
 - **Post-build processing**: `tools/elf2json.py` requires pyelftools; called automatically after build
 - **Two-pass plugin build**: Chips with plugin support (all except esp8266 and esp32) use a two-pass build: Pass 1 builds the base stub ELF, Pass 2 computes plugin addresses and builds the plugin ELF
-- **Chip support**: cmake defines 14 chips (esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4-rev1, esp32p4, esp8266), but build_all_chips.sh only builds 13 (excludes esp32h21)
+- **Chip support**: cmake defines 15 chips (esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4-rev1, esp32p4, esp32s31, esp8266), but build_all_chips.sh only builds 14 (excludes esp32h21)
 
 ## Common Issues and Workarounds
 

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -166,6 +166,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: stub-jsons
+          path: stub-jsons
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -177,4 +178,4 @@ jobs:
           draft: true
           prerelease: false
           fail_on_unmatched_files: true
-          files: stub-jsons/build*/esp*.json
+          files: stub-jsons/**/esp*.json

--- a/cmake/esp-targets.cmake
+++ b/cmake/esp-targets.cmake
@@ -4,7 +4,7 @@
 # Define supported ESP targets
 set(ESP8266_TARGET esp8266)
 set(XTENSA_TARGETS esp32 esp32s2 esp32s3)
-set(RISCV_TARGETS esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4-rev1 esp32p4)
+set(RISCV_TARGETS esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4-rev1 esp32p4 esp32s31)
 set(ALL_ESP_TARGETS ${ESP8266_TARGET} ${XTENSA_TARGETS} ${RISCV_TARGETS})
 
 # =============================================================================

--- a/src/ld/esp32s31.ld
+++ b/src/ld/esp32s31.ld
@@ -1,0 +1,6 @@
+MEMORY {
+  iram : org = 0x2F001000, len = 0x4500
+  dram : org = 0x2F00A000, len = 0x18000
+}
+
+INCLUDE common.ld

--- a/tools/build_all_chips.sh
+++ b/tools/build_all_chips.sh
@@ -21,6 +21,7 @@ ALL_CHIPS=(
     "esp32p4"
     "esp32s2"
     "esp32s3"
+    "esp32s31"
     "esp8266"
 )
 

--- a/unittests/target/run-tests.sh
+++ b/unittests/target/run-tests.sh
@@ -119,7 +119,7 @@ if [[ -z "$TARGET_CHIP" ]]; then
 fi
 
 # Validate target chip
-VALID_TARGETS="esp8266 esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4"
+VALID_TARGETS="esp8266 esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4 esp32s31"
 if [[ ! " $VALID_TARGETS " =~ " $TARGET_CHIP " ]]; then
     if [[ "$TARGET_CHIP" == "unknown" ]]; then
         print_error "No target chip specified."

--- a/unittests/target/run-tests.sh
+++ b/unittests/target/run-tests.sh
@@ -27,6 +27,24 @@ print_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+# Same chip list as cmake/esp-targets.cmake (ESP8266 + Xtensa + RISC-V); parse
+# the CMake file so run-tests validation cannot drift from the build system.
+load_valid_targets_from_cmake() {
+    local cmake_file="${1:?}"
+    if [[ ! -f "$cmake_file" ]]; then
+        print_error "Cannot find target definitions: $cmake_file"
+        exit 1
+    fi
+    VALID_TARGETS=$(grep -E '^set\((ESP8266_TARGET|XTENSA_TARGETS|RISCV_TARGETS) ' "$cmake_file" \
+        | sed -E 's/^set\((ESP8266_TARGET|XTENSA_TARGETS|RISCV_TARGETS) (.*)\)/\2/' \
+        | tr '\n' ' ')
+    VALID_TARGETS="${VALID_TARGETS% }"
+    if [[ -z "$VALID_TARGETS" ]]; then
+        print_error "Failed to parse ESP targets from $cmake_file"
+        exit 1
+    fi
+}
+
 # Print usage information
 usage() {
     echo "Usage: $0 [TARGET_CHIP] [OPTIONS]"
@@ -57,7 +75,10 @@ usage() {
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$SCRIPT_DIR"
+
+load_valid_targets_from_cmake "${REPO_ROOT}/cmake/esp-targets.cmake"
 
 print_status "ESP Flasher Stub Target Tests Runner"
 print_status "Working directory: $(pwd)"
@@ -118,8 +139,7 @@ if [[ -z "$TARGET_CHIP" ]]; then
     TARGET_CHIP="unknown"
 fi
 
-# Validate target chip
-VALID_TARGETS="esp8266 esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4 esp32s31"
+# Validate target chip (VALID_TARGETS loaded from cmake/esp-targets.cmake)
 if [[ ! " $VALID_TARGETS " =~ " $TARGET_CHIP " ]]; then
     if [[ "$TARGET_CHIP" == "unknown" ]]; then
         print_error "No target chip specified."


### PR DESCRIPTION
- Adds support for the ESP32-S31 target.
- Attempt to fix the release workflow to correctly locate artifacts.
- Sync target-test allowlist with CMake to remove the need for multiple target lists and fix P4 rev1 linker path