### PR TITLE
fix(flash): pass null flash state in stub main

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -43,8 +43,7 @@ void esp_main(void)
         stub_lib_clock_init();
     }
 
-    void *flash_state = NULL;
-    stub_lib_flash_init(&flash_state);
+    stub_lib_flash_init(NULL);
     stub_lib_flash_attach(0, false);
 
     stub_transport_init(transport);
@@ -75,7 +74,5 @@ void esp_main(void)
     }
 
     // Cleanup
-    if (flash_state) {
-        stub_lib_flash_deinit(flash_state);
-    }
+    stub_lib_flash_deinit(NULL);
 }


### PR DESCRIPTION
## Summary
- Pass `NULL` to `stub_lib_flash_init()` because the stub does not need flash state save/restore today.
- Keep cleanup explicit by calling `stub_lib_flash_deinit(NULL)` instead of tracking an unused state pointer.
- Avoid passing the address of a local pointer after the flash init API changes from `void **` to `void *`.

This is necessary due to latest changes in esp-stub-lib, just a heads-up.