### PR TITLE
fix(init): Prevent Guru Meditation error sduring clock initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.7.0 (2026-05-04)
+
+### ✨ New Features
+
+- **esp32s31**: Add USB-Serial/JTAG support *(Radim Karniš - 1d28e9c)*
+
+### 🐛 Bug Fixes
+
+- **init**: Prevent Guru Meditation error sduring clock initialization *(Radim Karniš - 76dbab8)*
+- **flash**: pass null flash state in stub main *(Jaroslav Burian - d459c62)*
+
+
 ## v0.6.0 (2026-04-17)
 
 ### ✨ New Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@
 
 [tool.commitizen]
     name = "czespressif"
-    version = "0.6.0"
+    version = "0.7.0"
     update_changelog_on_bump = true
     tag_format = "v$version"
     changelog_start_rev = "v0.0.1"


### PR DESCRIPTION
- Fixed Guru medtiation errors during clock init
- Released v0.7.0 (with S31 USB-Serial/JTAG support)