### PR TITLE
Add SDIO transport support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,5 +44,11 @@ add_link_options(${COMMON_LINKER_FLAGS})
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/esp-stub-lib)
 
+if(TARGET_CHIP STREQUAL "esp8266" AND TARGET miniz_obj)
+    # Keep miniz's unused tdefl static tables out of the ESP8266 stub without
+    # applying -fdata-sections globally, which increases size on other targets.
+    target_compile_options(miniz_obj PRIVATE -fdata-sections)
+endif()
+
 # Add stub target
 add_subdirectory(${CMAKE_SOURCE_DIR}/src)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ ninja -C build
 
 ## How It Works
 
-The flasher stub operates through upload, initialization, handshake (`OHAI` over SLIP), and a command loop that handles flash, memory, register, and SPI operations. For details, see the [Architecture](docs/architecture.md) document.
+The flasher stub operates through upload, initialization, handshake (`OHAI` over the selected transport), and a command loop that handles flash, memory, register, and SPI operations. UART and USB transports use SLIP framing; SDIO uses raw command frames. For details, see the [Architecture](docs/architecture.md) document.
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,22 +2,22 @@
 
 ## Overview
 
-The esp-flasher-stub firmware is a bare-metal C application that runs on ESP chip RAM. It communicates with a host tool (esptool) over a serial transport using the [SLIP](https://datatracker.ietf.org/doc/html/rfc1055) protocol to perform flash programming and other operations.
+The esp-flasher-stub firmware is a bare-metal C application that runs on ESP chip RAM. It communicates with a host tool (esptool) through a transport abstraction to perform flash programming and other operations. UART, USB-Serial-JTAG, and USB-OTG carry [SLIP](https://datatracker.ietf.org/doc/html/rfc1055)-framed commands; SDIO carries raw command frames.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  Host (esptool)                                         │
-│  Sends SLIP-framed commands over UART / USB             │
+│  Sends command frames over UART / USB / SDIO            │
 └───────────────────────┬─────────────────────────────────┘
                         │
-            UART / USB-Serial-JTAG / USB-OTG
+            UART / USB-Serial-JTAG / USB-OTG / SDIO
                         │
 ┌───────────────────────▼─────────────────────────────────┐
 │  ESP Flasher Stub (runs in chip RAM)                    │
 │                                                         │
 │  ┌──────────┐  ┌───────────────┐  ┌──────────────────┐  │
-│  │Transport │→ │ SLIP Protocol │→ │ Command Handler  │  │
-│  │  Layer   │  │   Decoder     │  │   & Dispatch     │  │
+│  │Transport │→ │ Frame Buffer  │→ │ Command Handler  │  │
+│  │  Layer   │  │ + SLIP/SDIO   │  │   & Dispatch     │  │
 │  └──────────┘  └───────────────┘  └────────┬─────────┘  │
 │                                            │            │
 │                                   ┌────────▼─────────┐  │
@@ -39,13 +39,14 @@ The esp-flasher-stub firmware is a bare-metal C application that runs on ESP chi
 ```
 src/
 ├── main.c              Entry point (esp_main), BSS init, main loop
-├── slip.c / slip.h     SLIP protocol framing (send and receive)
+├── frame_buffer.c / .h Shared double-buffered RX frame storage
+├── slip.c / slip.h     SLIP byte-stuffing and byte-stream decoding
 ├── command_handler.c   Command parsing, dispatch, and response
-├── command_handler.h   Public API and buffer size definitions
+├── command_handler.h   Command context and response API
 ├── commands.h          Command IDs and response codes
 ├── plugin_table.h      Function Pointer Table ABI (plugin system)
-├── nand_plugin.c       NAND flash plugin (9 handlers, ESP32-S3 only)
-├── transport.c / .h    Transport detection and initialization
+├── nand_plugin.c       NAND flash plugin (9 handlers)
+├── transport.c / .h    Transport detection, initialization, and RX/TX operations
 ├── endian_utils.h      Byte-order conversion helpers
 └── ld/                 Linker scripts (one per chip + common.ld + nand_plugin.ld)
 ```
@@ -86,6 +87,8 @@ The `common.ld` file defines sections (`.text`, `.bss`, `.data`) and sets the en
 ## Plugin System
 
 The stub supports runtime-loadable plugins that extend the command set. Plugins are dispatched through a **Function Pointer Table (FPT)**: a global array in the base stub's `.data` segment, indexed by opcode (range `0xD5`–`0xEF`). At startup all entries default to `s_plugin_unsupported`. esptool patches the relevant entries and uploads the plugin binary before handing off control.
+
+Command handlers and plugin post-process callbacks receive a `struct cmd_ctx` that includes the selected transport operations. Streaming code should send data and poll ACKs through `ctx->transport`, so plugin code stays independent of whether the host is using SLIP-based UART/USB or raw SDIO.
 
 For chips that support a plugin (currently ESP32-S3 with the NAND plugin), the build uses a **two-pass** process:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,8 @@ The build requires the `-DTARGET_CHIP=<chip>` parameter. The CMake configuration
 2. Selects the appropriate cross-compiler prefix (Xtensa or RISC-V).
 3. Applies architecture-specific compiler flags.
 4. Links with a chip-specific linker script from `src/ld/`.
-5. Runs `tools/elf2json.py` as a post-build step to generate the JSON stub file.
+5. Applies target-local size workarounds where needed, such as `-fdata-sections` only for ESP8266 `miniz_obj`.
+6. Runs `tools/elf2json.py` as a post-build step to generate the JSON stub file.
 
 ## Linker Scripts
 

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -31,11 +31,11 @@ typedef int (*plugin_cmd_handler_t)(uint8_t command,
 - `command` — the opcode byte.
 - `data` — pointer to the command payload.
 - `len` — payload length in bytes.
-- `resp` — output struct (zeroed by the dispatcher before the call); the handler fills `resp->value`, `resp->data[]`, and `resp->data_size` as needed.
+- `resp` — output struct (zeroed by the dispatcher before the call); the handler fills `resp->value`, `resp->data[]`, and `resp->data_size` as needed. Streaming handlers may also set `resp->post_process` to a callback that runs after the primary response has been sent.
 
-The handler returns an `esp_response_code` value (`RESPONSE_SUCCESS` == 0 on success). The base dispatcher owns SLIP response framing and the post-process step — handlers must **not** send their own SLIP frames.
+The handler returns an `esp_response_code` value (`RESPONSE_SUCCESS` == 0 on success). The base dispatcher owns primary response framing and the post-process step — handlers must **not** send their own response frames. Post-process callbacks receive `struct cmd_ctx`, including `ctx->transport`, and should use that transport for streaming data and polling ACK frames.
 
-Plugin handlers must use **BSS-only global state** — no initialized (`.data`) globals. Only zero-initialized globals (`.bss`) are permitted because only the `.text` and `.bss` sections are present in the plugin binary.
+Plugin handlers must use **BSS-only global state** — no initialized (`.data`) globals and no `.rodata` constants. Only zero-initialized globals (`.bss`) and code/const data emitted into `.text` are permitted because only the `.text` and `.bss` sections are present in the plugin binary.
 
 ### Dispatch
 
@@ -52,6 +52,8 @@ Before uploading the stub, esptool (Python side):
    3. Plugin `.text`
    4. Calls `mem_finish` to start execution
 
+After startup, plugin opcodes use the same command dispatcher and transport operations as base commands. Plugins do not link against base SLIP helper symbols; streaming callbacks use `ctx->transport`.
+
 ### Xtensa IRAM Caveat
 
 On Xtensa cores (ESP32-S2, ESP32-S3), IRAM only supports 32-bit stores. Writing non-4-byte-aligned data to IRAM causes a `LoadStoreError` exception (EXCCAUSE=3). `elf2json.py` automatically pads the plugin `.text` to a 4-byte boundary before embedding it in the JSON file.
@@ -66,7 +68,7 @@ Pass 1: cmake/ninja → base stub ELF
             ▼
 tools/compute_plugin_addrs.py
   Reads base stub ELF, extracts .text, .data, and .bss sizes,
-  computes PLUGIN_TEXT_ADDR and PLUGIN_BSS_ADDR
+  computes <NAME>_PLUGIN_TEXT_ADDR and <NAME>_PLUGIN_BSS_ADDR
             │
             ▼
 Pass 2: cmake/ninja → plugin ELF (linked at computed addresses)
@@ -81,7 +83,7 @@ tools/elf2json.py
 
 | File | Purpose |
 |---|---|
-| `tools/compute_plugin_addrs.py` | Extracts base ELF sizes and computes plugin load addresses |
+| `tools/compute_plugin_addrs.py` | Extracts base ELF sizes and computes one or more plugin load addresses |
 | `tools/elf2json.py` | Converts ELF to JSON; embeds plugin `.text` and `.bss` size |
 | `src/plugin_table.h` | FPT ABI constants and `plugin_cmd_handler_t` typedef |
 | `src/command_handler.c` | Opcode dispatch to FPT |
@@ -108,7 +110,7 @@ Pick unused opcodes from the `0xDE`–`0xEF` range (`0xD5`–`0xDD` are already 
 
 ### Step 2 — Create `src/spi_ram_plugin.c`
 
-Implement functions matching `plugin_cmd_handler_t`. Use only BSS globals (no `.data` initializers). Include `plugin_table.h`:
+Implement functions matching `plugin_cmd_handler_t`. Use only BSS globals (no `.data` initializers and no `.rodata` constants). Include `plugin_table.h`:
 
 ```c
 #include "plugin_table.h"
@@ -154,27 +156,27 @@ Implement target-specific functions (e.g., `src/target/esp32s3/src/spi_ram.c`) f
 
 ### Step 5 — Update `CMakeLists.txt`
 
-Add detection of the new HAL file (analogous to `_NAND_C`), then define an `add_executable` target for the plugin and pass the computed load addresses:
+Add detection of the new HAL file (analogous to `_NAND_C`), then call `stub_add_plugin()` with the plugin sources and computed load-address variable names:
 
 ```cmake
 set(_SPI_RAM_C ${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/src/spi_ram.c)
 
 if(EXISTS "${_SPI_RAM_C}")
-    add_executable(${SPI_RAM_PLUGIN_NAME}
-        spi_ram_plugin.c
-        ${_SPI_RAM_C}
-    )
-    target_link_options(${SPI_RAM_PLUGIN_NAME} PRIVATE
-        -T${PLUGIN_LD}
-        -Wl,--defsym,PLUGIN_TEXT_ADDR=${PLUGIN_TEXT_ADDR}
-        -Wl,--defsym,PLUGIN_BSS_ADDR=${PLUGIN_BSS_ADDR}
+    stub_add_plugin(
+        NAME          spi_ram
+        SOURCES
+            spi_ram_plugin.c
+            ${_SPI_RAM_C}
+        LINKER_SCRIPT ${LINKER_SCRIPTS_DIR}/spi_ram_plugin.ld
+        TEXT_ADDR     SPI_RAM_PLUGIN_TEXT_ADDR
+        BSS_ADDR      SPI_RAM_PLUGIN_BSS_ADDR
     )
 endif()
 ```
 
 ### Step 6 — Update `tools/elf2json.py`
 
-Add `--plugin spi_ram <elf>` argument handling. The script must read the plugin ELF's `.text` (padded to 4 bytes for Xtensa), resolve handler symbol addresses, and record the plugin in the output JSON under the `plugins` key:
+Register the plugin handler symbols in `PLUGIN_HANDLER_SYMBOLS`. `elf2json.py` already accepts repeated `--plugin <name> <elf>` arguments, reads each plugin ELF's `.text` (padded to 4 bytes for Xtensa), resolves handler symbol addresses, and records the plugin in the output JSON under the `plugins` key:
 
 ```json
 "plugins": {

--- a/docs/plugins/nand-flash.md
+++ b/docs/plugins/nand-flash.md
@@ -27,7 +27,7 @@ The W25N01GVxxxG/T/R family is supported (1 Gbit, SPI NAND).
 
 NAND support is implemented as a [plugin](../plugin-system.md) that runs on top of the base stub. The base stub JSON for ESP32-S3 includes a `plugins.nand` section with the plugin binary, load addresses, and a handler offset table. The host tool detects the plugin via the `plugins` key in the stub JSON and loads it when NAND operations are requested.
 
-Loading sequence: the host parses the base stub JSON, patches the Function Pointer Table (FPT) in the base stub `.data` segment with the per-opcode handler addresses from the plugin, appends plugin BSS zeros to the data upload, and uploads the plugin `.text` immediately after the base stub `.text`. After that, the host issues plugin opcodes using the same SLIP framing as base stub commands.
+Loading sequence: the host parses the base stub JSON, patches the Function Pointer Table (FPT) in the base stub `.data` segment with the per-opcode handler addresses from the plugin, appends plugin BSS zeros to the data upload, and uploads the plugin `.text` immediately after the base stub `.text`. After that, the host issues plugin opcodes using the same transport framing as base stub commands: SLIP for UART/USB transports and raw frames for SDIO.
 
 All NAND opcodes (`0xD5–0xDE`) are dispatched through the FPT. The handler signature is `plugin_cmd_handler_t` (see `plugin_table.h`).
 
@@ -77,7 +77,7 @@ All NAND opcodes (`0xD5–0xDE`) are dispatched through the FPT. The handler sig
 
 ### `0xDA` — `SPI_NAND_WRITE_FLASH_DATA`
 
-**Request payload**: 16-byte header (`data_len` at bytes 0–3, rest unused) + `data_len` bytes of flash data. The XOR checksum of the flash data must be in the SLIP framing header at offset −4 relative to the payload pointer.
+**Request payload**: 16-byte header (`data_len` at bytes 0–3, rest unused) + `data_len` bytes of flash data. The XOR checksum of the flash data must be in the command frame header at offset −4 relative to the payload pointer.
 
 **Response**: `RESPONSE_SUCCESS` after each packet. Mid-stream full-page flush errors are reported inline as `RESPONSE_FAILED_SPI_OP`.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(${TARGET_NAME}
     "main.c"
+    "frame_buffer.c"
     "slip.c"
     "command_handler.c"
     "transport.c"
@@ -103,10 +104,6 @@ if(NOT TARGET_CHIP STREQUAL "esp8266" AND NOT TARGET_CHIP STREQUAL "esp32")
             "-T${_PA_LINKER_SCRIPT}"
             -Wl,--defsym,PLUGIN_TEXT_ADDR=${${_PA_TEXT_ADDR}}
             -Wl,--defsym,PLUGIN_BSS_ADDR=${${_PA_BSS_ADDR}}
-            -Wl,--defsym,BASE_SLIP_SEND_FRAME=${SLIP_SEND_FRAME_ADDR}
-            -Wl,--defsym,BASE_SLIP_RECV_RESET=${SLIP_RECV_RESET_ADDR}
-            -Wl,--defsym,BASE_SLIP_IS_FRAME_COMPLETE=${SLIP_IS_FRAME_COMPLETE_ADDR}
-            -Wl,--defsym,BASE_SLIP_GET_FRAME_DATA=${SLIP_GET_FRAME_DATA_ADDR}
             -Wl,-Map=${CMAKE_BINARY_DIR}/${_plugin_target}.map
             ${_rom_ld_flags}
         )

--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -16,7 +16,7 @@
 #include <esp-stub-lib/security.h>
 #include <esp-stub-lib/miniz.h>
 #include <esp-stub-lib/md5.h>
-#include "slip.h"
+#include "transport.h"
 #include "commands.h"
 #include "command_handler.h"
 #include "endian_utils.h"
@@ -55,7 +55,10 @@ struct flash_operation_state {
 static struct flash_operation_state s_flash_state = {0};
 static struct memory_operation_state s_memory_state = {0};
 
-static void s_send_response(uint8_t command, int response_code, const struct command_response_data *response_data);
+static void s_send_response(const struct stub_transport_ops *transport,
+                            uint8_t command,
+                            int response_code,
+                            const struct command_response_data *response_data);
 
 /*
  * Default plugin handler for unpatched FPT slots.
@@ -93,9 +96,12 @@ static inline int s_validate_checksum(const uint8_t *data, uint32_t size, uint32
     return RESPONSE_SUCCESS;
 }
 
-static void s_send_response(uint8_t command, int response_code, const struct command_response_data *response_data)
+static void s_send_response(const struct stub_transport_ops *transport,
+                            uint8_t command,
+                            int response_code,
+                            const struct command_response_data *response_data)
 {
-    uint8_t response_buffer[MAX_RESPONSE_SIZE] = {0};
+    uint8_t response_buffer[MAX_RESPONSE_SIZE] __attribute__((aligned(4))) = {0};
 
     uint16_t data_size = response_data ? response_data->data_size : 0U;
     if (data_size > MAX_RESPONSE_DATA_SIZE) {
@@ -123,7 +129,7 @@ static void s_send_response(uint8_t command, int response_code, const struct com
     // Write response code in big-endian format (remote reads as ">H")
     set_u16_to_be(ptr, (uint16_t)response_code);
 
-    slip_send_frame(response_buffer, total_frame_size);
+    transport->send_frame(response_buffer, total_frame_size);
 }
 
 static inline int s_check_flash_in_progress(void)
@@ -329,7 +335,7 @@ static int s_sync(const struct cmd_ctx *ctx)
      * ROM bootloader also sends 8 responses (7 here, last one as return command response) but with non-zero values.
      * The value 0 is used by esptool to detect that it's talking to a flasher stub. */
     for (int i = 0; i < 7; ++i) {
-        s_send_response(ESP_SYNC, RESPONSE_SUCCESS, NULL);
+        s_send_response(ctx->transport, ESP_SYNC, RESPONSE_SUCCESS, NULL);
     }
 
     return RESPONSE_SUCCESS;
@@ -723,8 +729,8 @@ static int s_read_flash_post_process(const struct cmd_ctx *ctx)
         return RESPONSE_BAD_DATA_LEN;
     }
 
-    // Reset slip receive state to avoid reading READ_FLASH command again
-    slip_recv_reset();
+    // Release the READ_FLASH command frame so the buffer can receive ACKs
+    ctx->transport->recv_release();
 
     uint32_t read_size_remaining = read_size;
     uint32_t sent_packets = 0;
@@ -736,15 +742,18 @@ static int s_read_flash_post_process(const struct cmd_ctx *ctx)
 
     while (read_size_remaining > 0 || acked_data_size < read_size) {
         // Check if packet acknowledgement from a host arrived
-        if (slip_is_frame_complete()) {
-            size_t slip_size;
-            const uint8_t *slip_data = slip_get_frame_data(&slip_size);
-            if (slip_size != sizeof(acked_data_size)) {
+        size_t ack_size;
+        bool ack_error;
+        const uint8_t *ack_data = ctx->transport->recv_poll(&ack_size, &ack_error);
+        if (ack_error) {
+            ctx->transport->recv_release();
+        } else if (ack_data != NULL) {
+            if (ack_size != sizeof(acked_data_size)) {
                 break;
             }
-            memcpy(&acked_data_size, slip_data, sizeof(acked_data_size));
+            memcpy(&acked_data_size, ack_data, sizeof(acked_data_size));
             acked_packets++;
-            slip_recv_reset();
+            ctx->transport->recv_release();
         }
 
         // If not all data was read and max in-flight packets was not reached, read more data
@@ -762,16 +771,20 @@ static int s_read_flash_post_process(const struct cmd_ctx *ctx)
 
             // Use the data starting from the alignment offset
             uint8_t *actual_data = data + align_offset;
+            if (((uintptr_t)actual_data & 3U) != 0U) {
+                memmove(data, actual_data, actual_read_size);
+                actual_data = data;
+            }
             stub_lib_md5_update(&md5_ctx, actual_data, actual_read_size);
-            slip_send_frame(actual_data, actual_read_size);
+            ctx->transport->send_frame(actual_data, actual_read_size);
             offset += actual_read_size;
             read_size_remaining -= actual_read_size;
             sent_packets++;
         }
     }
-    uint8_t md5[16];
+    uint8_t md5[16] __attribute__((aligned(4)));
     stub_lib_md5_final(&md5_ctx, md5);
-    slip_send_frame(md5, sizeof(md5));
+    ctx->transport->send_frame(md5, sizeof(md5));
 
     return RESPONSE_SUCCESS;
 }
@@ -832,7 +845,7 @@ static int s_erase_region(const struct cmd_ctx *ctx)
 #undef ERASE_PER_SECTOR_TIMEOUT_US
 }
 
-void handle_command(const uint8_t *buffer, size_t size)
+void handle_command(const uint8_t *buffer, size_t size, const struct stub_transport_ops *transport)
 {
     // Accumulates errors from previous post-process and current command
     static int accumulated_result = RESPONSE_SUCCESS;
@@ -848,12 +861,12 @@ void handle_command(const uint8_t *buffer, size_t size)
     const uint8_t *data = ptr;
 
     if (direction != DIRECTION_REQUEST) {
-        s_send_response(command, RESPONSE_INVALID_COMMAND, NULL);
+        s_send_response(transport, command, RESPONSE_INVALID_COMMAND, NULL);
         return;
     }
 
     if (size != (size_t)(packet_size + HEADER_SIZE)) {
-        s_send_response(command, RESPONSE_BAD_DATA_LEN, NULL);
+        s_send_response(transport, command, RESPONSE_BAD_DATA_LEN, NULL);
         return;
     }
 
@@ -863,12 +876,13 @@ void handle_command(const uint8_t *buffer, size_t size)
         .direction = direction,
         .packet_size = packet_size,
         .checksum = checksum,
-        .data = data
+        .data = data,
+        .transport = transport
     };
 
     // If previous post-process failed, send that error and skip command execution
     if (accumulated_result != RESPONSE_SUCCESS) {
-        s_send_response(command, accumulated_result, NULL);
+        s_send_response(transport, command, accumulated_result, NULL);
         accumulated_result = RESPONSE_SUCCESS;
         return;
     }
@@ -980,9 +994,9 @@ void handle_command(const uint8_t *buffer, size_t size)
     }
 
     if (accumulated_result == RESPONSE_SUCCESS) {
-        s_send_response(command, RESPONSE_SUCCESS, &response);
+        s_send_response(transport, command, RESPONSE_SUCCESS, &response);
     } else {
-        s_send_response(command, accumulated_result, NULL);
+        s_send_response(transport, command, accumulated_result, NULL);
         s_pending_post_process = NULL;
     }
 

--- a/src/command_handler.h
+++ b/src/command_handler.h
@@ -13,10 +13,9 @@
 extern "C" {
 #endif
 
-// 0x4000 plus 0xFF is the maximum data size sent by esptool (WRITE_FLASH command), so keeping for the compatibility
-#define ESPTOOL_MAX_DATA_SIZE (0x4000U + 0xFFU)
+struct stub_transport_ops;
+
 #define HEADER_SIZE 8U
-#define MAX_COMMAND_SIZE (HEADER_SIZE + ESPTOOL_MAX_DATA_SIZE)
 
 /** Maximum number of extra data bytes a command response may carry. */
 #define MAX_RESPONSE_DATA_SIZE 64U
@@ -34,6 +33,7 @@ struct cmd_ctx {
     uint16_t packet_size;
     uint32_t checksum;
     const uint8_t *data;
+    const struct stub_transport_ops *transport;
 };
 
 /**
@@ -46,9 +46,9 @@ struct cmd_ctx {
  *      Set to NULL when no post-processing is needed.
  *   3. Return a status code (RESPONSE_SUCCESS or an error code).
  *
- * Handlers MUST NOT call SLIP functions directly for the primary response frame —
- * the dispatcher owns framing via s_send_response(). Streaming frames emitted
- * inside a post_process callback may still use slip_send_frame() directly.
+ * Handlers MUST NOT send the primary response frame themselves. The dispatcher
+ * owns framing via s_send_response(). Streaming frames emitted inside a
+ * post_process callback should use ctx->transport.
  */
 struct command_response_data {
     uint32_t value;                        /**< 4-byte value field in the response header */
@@ -66,7 +66,7 @@ struct command_response_data {
  * @param len Length of the buffer
  */
 
-void handle_command(const uint8_t *buffer, size_t len);
+void handle_command(const uint8_t *buffer, size_t len, const struct stub_transport_ops *transport);
 
 #ifdef __cplusplus
 }

--- a/src/frame_buffer.c
+++ b/src/frame_buffer.c
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include "frame_buffer.h"
+
+/*
+ * Two buffers: one being received into (s_rx_idx), one being processed (s_proc_idx).
+ * Their roles are fixed — no dynamic search needed.
+ * ~30% performance improvement over single-buffer for USB-Serial/JTAG flashing.
+ */
+struct frame_buffer {
+    uint8_t buffer[FRAME_BUFFER_SIZE] __attribute__((aligned(4)));
+    volatile size_t frame_length;
+    volatile bool frame_complete;
+    volatile bool frame_error;
+};
+
+static struct frame_buffer s_buffers[2];
+static volatile uint8_t s_rx_idx = 0;
+static volatile uint8_t s_proc_idx = 0;
+
+void frame_buffer_mark_error(void)
+{
+    s_buffers[s_rx_idx].frame_error = true;
+}
+
+uint8_t *frame_buffer_acquire(void)
+{
+    if (s_buffers[s_rx_idx].frame_complete || s_buffers[s_rx_idx].frame_error) {
+        uint8_t other = (uint8_t)(1U - s_rx_idx);
+        if (s_buffers[other].frame_complete || s_buffers[other].frame_error) {
+            return NULL;
+        }
+        s_rx_idx = other;
+    }
+    s_buffers[s_rx_idx].frame_length = 0;
+    return s_buffers[s_rx_idx].buffer;
+}
+
+void frame_buffer_mark_complete(size_t len)
+{
+    struct frame_buffer *rx_buf = &s_buffers[s_rx_idx];
+    if (len > FRAME_BUFFER_SIZE) {
+        rx_buf->frame_error = true;
+        return;
+    }
+    rx_buf->frame_length = len;
+    rx_buf->frame_complete = true;
+}
+
+enum frame_buffer_state frame_buffer_get_state(void)
+{
+    uint8_t other = (uint8_t)(1U - s_rx_idx);
+    if (s_buffers[other].frame_error)       {
+        s_proc_idx = other;
+        return FRAME_BUFFER_STATE_ERROR;
+    }
+    if (s_buffers[s_rx_idx].frame_error)    {
+        s_proc_idx = s_rx_idx;
+        return FRAME_BUFFER_STATE_ERROR;
+    }
+    if (s_buffers[other].frame_complete)    {
+        s_proc_idx = other;
+        return FRAME_BUFFER_STATE_COMPLETE;
+    }
+    if (s_buffers[s_rx_idx].frame_complete) {
+        s_proc_idx = s_rx_idx;
+        return FRAME_BUFFER_STATE_COMPLETE;
+    }
+    return FRAME_BUFFER_STATE_IDLE;
+}
+
+const uint8_t *frame_buffer_get_data(size_t *length)
+{
+    *length = s_buffers[s_proc_idx].frame_length;
+    return s_buffers[s_proc_idx].buffer;
+}
+
+/*
+ * Releases ONLY the buffer last selected by frame_buffer_get_state()
+ * (s_proc_idx). It must never touch the buffer the ISR/DMA is currently
+ * filling (s_rx_idx), is idempotent (clearing an already-clear buffer is a
+ * no-op), and never re-arms. The transport layer relies on all three
+ * properties: READ_FLASH's post-process releases the command frame early and
+ * the main loop releases it again afterwards, so a double release must be
+ * harmless. Do not add re-arming or s_rx_idx handling here.
+ */
+void frame_buffer_reset(void)
+{
+    s_buffers[s_proc_idx].frame_length = 0;
+    s_buffers[s_proc_idx].frame_complete = false;
+    s_buffers[s_proc_idx].frame_error = false;
+}

--- a/src/frame_buffer.h
+++ b/src/frame_buffer.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Maximum frame size: 8-byte SLIP header + esptool max data payload (WRITE_FLASH uses 0x4000+0xFF). */
+#define FRAME_BUFFER_SIZE (8U + 0x4000U + 0xFFU)
+
+enum frame_buffer_state {
+    FRAME_BUFFER_STATE_IDLE,
+    FRAME_BUFFER_STATE_COMPLETE,
+    FRAME_BUFFER_STATE_ERROR,
+};
+
+void frame_buffer_mark_error(void);
+
+uint8_t *frame_buffer_acquire(void);
+void frame_buffer_mark_complete(size_t len);
+
+enum frame_buffer_state frame_buffer_get_state(void);
+const uint8_t *frame_buffer_get_data(size_t *length);
+void frame_buffer_reset(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ld/esp32.ld
+++ b/src/ld/esp32.ld
@@ -2,7 +2,7 @@
    of available RAM, to reduce change of colliding with anything
    else... */
 MEMORY {
-  iram : org = 0x400A8000, len = 0x2000
+  iram : org = 0x400A8000, len = 0x2100
   dram : org = 0x3ffcc000, len = 0x14000
 }
 

--- a/src/ld/nand_plugin.ld
+++ b/src/ld/nand_plugin.ld
@@ -8,26 +8,12 @@
  * The following values must be supplied via -Wl,--defsym by CMake:
  *   PLUGIN_TEXT_ADDR          — IRAM load address (base text_end, 16-byte aligned)
  *   PLUGIN_BSS_ADDR           — DRAM load address (base data_end, 4-byte aligned)
- *   BASE_SLIP_SEND_FRAME      — address of slip_send_frame in base stub
- *   BASE_SLIP_RECV_RESET      — address of slip_recv_reset in base stub
- *   BASE_SLIP_IS_FRAME_COMPLETE  — address of slip_is_frame_complete in base stub
- *   BASE_SLIP_GET_FRAME_DATA  — address of slip_get_frame_data in base stub
  */
 
 MEMORY {
     iram : org = PLUGIN_TEXT_ADDR, len = 0x8000
     dram : org = PLUGIN_BSS_ADDR,  len = 0x4000
 }
-
-/*
- * Forward SLIP calls to the base stub's implementations.  The ISR writes into
- * the base stub's SLIP receive buffers, so the plugin must use them for RX too.
- * PROVIDE is ignored if a compiled object already defines the symbol.
- */
-PROVIDE(slip_send_frame         = BASE_SLIP_SEND_FRAME);
-PROVIDE(slip_recv_reset         = BASE_SLIP_RECV_RESET);
-PROVIDE(slip_is_frame_complete  = BASE_SLIP_IS_FRAME_COMPLETE);
-PROVIDE(slip_get_frame_data     = BASE_SLIP_GET_FRAME_DATA);
 
 /* Override the ENTRY(esp_main) from common.ld — the plugin has no esp_main */
 ENTRY(nand_plugin_attach)

--- a/src/main.c
+++ b/src/main.c
@@ -38,7 +38,7 @@ void esp_main(void)
     // stub_lib_clock_init() increases CPU frequency which benefits both USB and UART transfers.
     // Currently only enabled for USB transfers due to concerns about instability (observed on ESP32-S3),
     // because DBIAS voltage not being set. This needs investigation and potentially enabling for all transport types.
-    if (transport == TRANSPORT_USB_OTG || transport == TRANSPORT_USB_SERIAL_JTAG) {
+    if (transport == TRANSPORT_USB_OTG || transport == TRANSPORT_USB_SERIAL_JTAG || transport == TRANSPORT_SDIO) {
         stub_lib_clock_init();
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,6 @@
 #include <esp-stub-lib/clock.h>
 #include <esp-stub-lib/usb_otg.h>
 #include "command_handler.h"
-#include "slip.h"
 #include "transport.h"
 
 #ifdef ESP8266
@@ -39,36 +38,39 @@ void esp_main(void)
     // stub_lib_clock_init() increases CPU frequency which benefits both USB and UART transfers.
     // Currently only enabled for USB transfers due to concerns about instability (observed on ESP32-S3),
     // because DBIAS voltage not being set. This needs investigation and potentially enabling for all transport types.
-    if (transport == STUB_TRANSPORT_USB_OTG || transport == STUB_TRANSPORT_USB_SERIAL_JTAG) {
+    if (transport == TRANSPORT_USB_OTG || transport == TRANSPORT_USB_SERIAL_JTAG) {
         stub_lib_clock_init();
     }
 
     stub_lib_flash_init(NULL);
     stub_lib_flash_attach(0, false);
-
-    stub_transport_init(transport);
+    const struct stub_transport_ops *ops = stub_transport_init(transport);
 
     // Send OHAI greeting to signal stub is active
-    const uint8_t greeting[4] = {'O', 'H', 'A', 'I'};
-    slip_send_frame(&greeting, sizeof(greeting));
+    const uint8_t greeting[4] __attribute__((aligned(4))) = {'O', 'H', 'A', 'I'};
+    ops->send_frame(&greeting, sizeof(greeting));
 
     for (;;) {
-        int frame_state = slip_get_frame_state();
-        if (frame_state == SLIP_STATE_COMPLETE) {
-            size_t frame_length;
-            const uint8_t *frame_data = slip_get_frame_data(&frame_length);
-            handle_command(frame_data, frame_length);
-            slip_recv_reset();
+        size_t frame_length;
+        bool frame_error;
+        const uint8_t *frame_data = ops->recv_poll(&frame_length, &frame_error);
+
+        if (frame_error) {
+            ops->recv_release();
             continue;
         }
 
-        if (frame_state == SLIP_STATE_ERROR) {
-            slip_recv_reset();
+        if (frame_data != NULL) {
+            handle_command(frame_data, frame_length, ops);
+            // Redundant for post-process commands (e.g. READ_FLASH) that release
+            // the command frame themselves; recv_release is idempotent and never
+            // touches the buffer being received into, so this is safe.
+            ops->recv_release();
             continue;
         }
 
         // Handle chip reset requests via CDC-ACM RTS line toggling in USB-OTG mode
-        if (transport == STUB_TRANSPORT_USB_OTG && stub_lib_usb_otg_is_reset_requested()) {
+        if (transport == TRANSPORT_USB_OTG && stub_lib_usb_otg_is_reset_requested()) {
             stub_lib_usb_otg_handle_reset();
         }
     }

--- a/src/nand_plugin.c
+++ b/src/nand_plugin.c
@@ -5,9 +5,8 @@
  *
  * NAND flash plugin — compiled as a separate binary loaded at runtime by esptool.
  *
- * SLIP functions (slip_send_frame, slip_recv_reset, slip_is_frame_complete,
- * slip_get_frame_data) are forwarded to the base stub via PROVIDE in the linker
- * script. They access the same SLIP state that the UART ISR writes to.
+ * Streaming post-process callbacks use ctx->transport, so the plugin stays
+ * independent of the concrete link protocol selected by the base stub.
  */
 #include <stdint.h>
 #include <string.h>
@@ -19,12 +18,7 @@
 #include "command_handler.h"
 #include "endian_utils.h"
 #include "plugin_table.h"
-
-/* ---- SLIP forward declarations (resolved to base stub via PROVIDE) --------- */
-extern void slip_send_frame(const void *data, size_t size);
-extern void slip_recv_reset(void);
-extern bool slip_is_frame_complete(void);
-extern const uint8_t *slip_get_frame_data(size_t *length);
+#include "transport.h"
 
 /* ---- NAND geometry constants ----------------------------------------------- */
 #define NAND_PAGE_SIZE 2048
@@ -81,7 +75,7 @@ static struct {
  * NAND read operation state — stashed in plugin BSS so the post-process
  * callback can pick up parameters parsed by nand_plugin_read_flash.
  * Using BSS avoids data-layout assumptions about the command payload pointer
- * (whose lifetime ends when slip_recv_reset() is called at the top of the
+ * (whose lifetime ends when recv_release() is called at the top of the
  * streaming loop).  This mirrors the base stub's s_flash_state pattern.
  */
 static struct {
@@ -173,8 +167,6 @@ static int nand_fill_send_buf(uint8_t *send_buf, uint8_t *page_buf,
  */
 static int s_nand_read_flash_post_process(const struct cmd_ctx *ctx)
 {
-    (void)ctx;
-
     uint32_t offset = s_nand_read_state.offset;
     uint32_t read_size = s_nand_read_state.read_size;
     uint32_t packet_size = s_nand_read_state.packet_size;
@@ -186,8 +178,8 @@ static int s_nand_read_flash_post_process(const struct cmd_ctx *ctx)
      * this bound before we are called. */
     static uint8_t send_buf[NAND_PAGE_SIZE * 2] __attribute__((aligned(4)));
 
-    /* Reset receive state to accept ACK frames from the host */
-    slip_recv_reset();
+    /* Release the READ_FLASH command frame so the buffer can receive ACKs */
+    ctx->transport->recv_release();
 
     uint32_t read_size_remaining = read_size;
     uint32_t sent_packets = 0;
@@ -200,10 +192,12 @@ static int s_nand_read_flash_post_process(const struct cmd_ctx *ctx)
     stub_lib_md5_init(&md5_ctx);
 
     while (read_size_remaining > 0 || acked_data_size < read_size) {
-        /* Check for ACK from host */
-        if (slip_is_frame_complete()) {
-            size_t slip_size;
-            const uint8_t *slip_data = slip_get_frame_data(&slip_size);
+        size_t slip_size;
+        bool ack_error;
+        const uint8_t *slip_data = ctx->transport->recv_poll(&slip_size, &ack_error);
+        if (ack_error) {
+            ctx->transport->recv_release();
+        } else if (slip_data != NULL) {
             if (slip_size == sizeof(acked_data_size)) {
                 memcpy(&acked_data_size, slip_data, sizeof(acked_data_size));
                 /* Only count ACKs for validated frames, and never exceed sent_packets */
@@ -211,7 +205,7 @@ static int s_nand_read_flash_post_process(const struct cmd_ctx *ctx)
                     acked_packets++;
                 }
             }
-            slip_recv_reset();
+            ctx->transport->recv_release();
         }
 
         /* Avoid unsigned underflow when computing unacked packet count */
@@ -239,7 +233,7 @@ static int s_nand_read_flash_post_process(const struct cmd_ctx *ctx)
             }
 
             stub_lib_md5_update(&md5_ctx, send_buf, actual_read_size);
-            slip_send_frame(send_buf, actual_read_size);
+            ctx->transport->send_frame(send_buf, actual_read_size);
             read_size_remaining -= actual_read_size;
             sent_packets++;
         }
@@ -252,7 +246,7 @@ static int s_nand_read_flash_post_process(const struct cmd_ctx *ctx)
             md5[i] ^= 0xFF;  /* intentionally corrupt — see comment above */
         }
     }
-    slip_send_frame(md5, sizeof(md5));
+    ctx->transport->send_frame(md5, sizeof(md5));
     return RESPONSE_SUCCESS;
 }
 

--- a/src/plugin_table.h
+++ b/src/plugin_table.h
@@ -34,9 +34,9 @@
  *      Leave resp->post_process as NULL when no post-processing is needed.
  *   3. Return RESPONSE_SUCCESS or an error code.
  *
- * The dispatcher (command_handler.c:s_send_response) owns primary SLIP framing —
+ * The dispatcher (command_handler.c:s_send_response) owns primary response framing —
  * handlers MUST NOT send the response frame themselves.  Streaming frames inside
- * a post_process callback may still call slip_send_frame() directly.
+ * a post_process callback should use ctx->transport.
  *
  * Return value (esp_response_code):
  *   RESPONSE_SUCCESS (0): dispatcher sends a success frame, then calls

--- a/src/slip.c
+++ b/src/slip.c
@@ -4,41 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <esp-stub-lib/uart.h>
-#include <esp-stub-lib/usb_serial_jtag.h>
-#include "command_handler.h"
+#include "frame_buffer.h"
 #include "slip.h"
 
-/*
- * Number of buffers for zero-copy operation. Two are taken from old implementation and has around
- * 30 % performance improvement for flashing over USB-Serial/JTAG (depends on the target and flash chip)
- * more buffers might be beneficial for higher transfer speeds (not tested yet).
- */
-#define SLIP_NUM_BUFFERS 2
+/* SLIP wire encoding constants — private to this file */
+#define SLIP_END     0xC0
+#define SLIP_ESC     0xDB
+#define SLIP_ESC_END 0xDC
+#define SLIP_ESC_ESC 0xDD
 
-/* SLIP State Machine */
-enum slip_state {
-    STATE_NO_FRAME,          /* Not in a frame */
-    STATE_IN_FRAME,          /* Processing frame data */
-    STATE_ESCAPING           /* Processing escape sequence */
+/* RX state machine */
+enum slip_rx_state {
+    STATE_NO_FRAME,
+    STATE_IN_FRAME,
+    STATE_ESCAPING,
 };
 
-struct slip_buffer {
-    uint8_t buffer[MAX_COMMAND_SIZE] __attribute__((aligned(4)));
-    volatile size_t frame_length;
-    volatile bool frame_complete;
-    volatile bool frame_error;
-};
+static volatile enum slip_rx_state s_state = STATE_NO_FRAME;
+static uint8_t *volatile s_rx_buf;
+static volatile size_t s_rx_len;
+static volatile size_t s_rx_cap;
 
-static struct slip_buffer s_buffers[SLIP_NUM_BUFFERS];
-static volatile uint8_t s_receiving_buffer = 0;
-static volatile uint8_t s_processing_buffer = 0;
-static volatile enum slip_state s_state = STATE_NO_FRAME;
-
-/* TX function pointer set by transport init (defaults to UART) */
+/* TX hooks — set once during transport init */
 static uint8_t (*s_tx_one_char)(uint8_t) = stub_lib_uart_tx_one_char;
-/* Flush function pointer set by transport init (optional) */
 static void (*s_flush_fn)(void) = NULL;
 
 void slip_set_tx_fn(uint8_t (*tx_fn)(uint8_t))
@@ -53,12 +44,14 @@ void slip_set_flush_fn(void (*flush_fn)(void))
     s_flush_fn = flush_fn;
 }
 
-void slip_send_frame_delimiter(void)
+static void slip_flush(void)
 {
-    s_tx_one_char(SLIP_END);
+    if (s_flush_fn) {
+        s_flush_fn();
+    }
 }
 
-void slip_send_frame_data(uint8_t byte)
+static void send_escaped_byte(uint8_t byte)
 {
     switch (byte) {
     case SLIP_END:
@@ -75,154 +68,81 @@ void slip_send_frame_data(uint8_t byte)
     }
 }
 
-void slip_send_frame_data_buf(const void *data, size_t size)
+bool slip_send_frame(const void *data, size_t size)
 {
     if (!data) {
-        return;
+        return false;
     }
-
+    s_tx_one_char(SLIP_END);
     const uint8_t *buf = (const uint8_t *)data;
     for (size_t i = 0; i < size; i++) {
-        slip_send_frame_data(buf[i]);
+        send_escaped_byte(buf[i]);
     }
-}
-
-void slip_flush(void)
-{
-    if (s_flush_fn) {
-        s_flush_fn();
-    }
-}
-
-void slip_send_frame(const void *data, size_t size)
-{
-    if (!data) {
-        return;
-    }
-
-    slip_send_frame_delimiter();
-    slip_send_frame_data_buf(data, size);
-    slip_send_frame_delimiter();
+    s_tx_one_char(SLIP_END);
     slip_flush();
+    return true;
+}
+
+/*
+ * Append one decoded byte to the active RX buffer. Overrunning the buffer
+ * marks the frame as an error and aborts reception — without this guard a
+ * host frame larger than the buffer would corrupt memory from inside the ISR.
+ */
+static void rx_put(uint8_t byte)
+{
+    if (s_rx_len < s_rx_cap) {
+        s_rx_buf[s_rx_len++] = byte;
+    } else {
+        frame_buffer_mark_error();
+        s_rx_buf = NULL;
+        s_state = STATE_NO_FRAME;
+    }
 }
 
 void slip_recv_byte(uint8_t byte)
 {
-    struct slip_buffer *rx_buf = &s_buffers[s_receiving_buffer];
-
-    /* If current buffer is full, switch to next available buffer */
-    if (rx_buf->frame_complete || rx_buf->frame_error) {
-        bool found = false;
-        for (uint8_t i = 1; i < SLIP_NUM_BUFFERS; i++) {
-            uint8_t next_buf = (s_receiving_buffer + i) % SLIP_NUM_BUFFERS;
-            if (!s_buffers[next_buf].frame_complete && !s_buffers[next_buf].frame_error) {
-                s_receiving_buffer = next_buf;
-                rx_buf = &s_buffers[s_receiving_buffer];
-                found = true;
-                break;
-            }
-        }
-
-        /* If no available buffer, drop the byte */
-        if (!found) {
-            return;
-        }
-    }
-
     switch (s_state) {
     case STATE_NO_FRAME:
-        if (byte == SLIP_END) {
+        if (byte == SLIP_END && s_rx_buf) {
+            s_rx_len = 0;
             s_state = STATE_IN_FRAME;
-            rx_buf->frame_length = 0;
         }
         break;
 
     case STATE_IN_FRAME:
         if (byte == SLIP_END) {
-            if (rx_buf->frame_length > 0) {
-                rx_buf->frame_complete = true;
+            if (s_rx_len > 0) {
+                frame_buffer_mark_complete(s_rx_len);
+                s_rx_buf = NULL;    /* main loop rearmed via slip_recv_poll */
             }
+            /* else: zero-length frame (C0 C0 gap) — keep buffer armed so
+             * the ISR can immediately start the next real frame. */
+            s_rx_len = 0;
             s_state = STATE_NO_FRAME;
         } else if (byte == SLIP_ESC) {
             s_state = STATE_ESCAPING;
         } else {
-            if (rx_buf->frame_length < MAX_COMMAND_SIZE) {
-                rx_buf->buffer[rx_buf->frame_length] = byte;
-                ++rx_buf->frame_length;
-            } else {
-                rx_buf->frame_error = true;
-                s_state = STATE_NO_FRAME;
-            }
+            rx_put(byte);
         }
         break;
 
     case STATE_ESCAPING:
         s_state = STATE_IN_FRAME;
         if (byte == SLIP_ESC_END) {
-            byte = SLIP_END;
+            rx_put(SLIP_END);
         } else if (byte == SLIP_ESC_ESC) {
-            byte = SLIP_ESC;
+            rx_put(SLIP_ESC);
         } else {
-            rx_buf->frame_error = true;
-            s_state = STATE_NO_FRAME;
-            return;
-        }
-
-        if (rx_buf->frame_length < MAX_COMMAND_SIZE) {
-            rx_buf->buffer[rx_buf->frame_length] = byte;
-            ++rx_buf->frame_length;
-        } else {
-            rx_buf->frame_error = true;
+            frame_buffer_mark_error();
+            s_rx_buf = NULL;
             s_state = STATE_NO_FRAME;
         }
         break;
     }
 }
 
-bool slip_is_frame_complete(void)
+void slip_rearm(uint8_t *buf, size_t cap)
 {
-    for (uint8_t i = 0; i < SLIP_NUM_BUFFERS; i++) {
-        if (s_buffers[i].frame_complete) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool slip_is_frame_error(void)
-{
-    return s_buffers[s_processing_buffer].frame_error;
-}
-
-int slip_get_frame_state(void)
-{
-    /* Check all buffers for complete or error frames */
-    for (uint8_t i = 0; i < SLIP_NUM_BUFFERS; i++) {
-        if (s_buffers[i].frame_error) {
-            s_processing_buffer = i;
-            return SLIP_STATE_ERROR;
-        }
-
-        if (s_buffers[i].frame_complete) {
-            s_processing_buffer = i;
-            return SLIP_STATE_COMPLETE;
-        }
-    }
-
-    return SLIP_STATE_IDLE;
-}
-
-const uint8_t *slip_get_frame_data(size_t *length)
-{
-    if (length) {
-        *length = s_buffers[s_processing_buffer].frame_length;
-    }
-    return s_buffers[s_processing_buffer].buffer;
-}
-
-void slip_recv_reset(void)
-{
-    s_buffers[s_processing_buffer].frame_length = 0;
-    s_buffers[s_processing_buffer].frame_complete = false;
-    s_buffers[s_processing_buffer].frame_error = false;
+    s_rx_buf = buf;
+    s_rx_cap = cap;
 }

--- a/src/slip.h
+++ b/src/slip.h
@@ -6,131 +6,64 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* SLIP Protocol Constants */
-#define SLIP_END            0xC0    /* Frame delimiter */
-#define SLIP_ESC            0xDB    /* Escape character */
-#define SLIP_ESC_END        0xDC    /* Escaped frame delimiter */
-#define SLIP_ESC_ESC        0xDD    /* Escaped escape character */
-
-enum slip_frame_state {
-    SLIP_STATE_IDLE,         /* No frame processing */
-    SLIP_STATE_COMPLETE,     /* Frame complete and ready */
-    SLIP_STATE_ERROR,        /* Frame error occurred */
-};
-
 /**
  * @brief Register TX function used by SLIP to send bytes
- *
- * The function must transmit a single byte and return 0 on success.
  *
  * @param tx_fn Function pointer with signature: uint8_t (*)(uint8_t)
  */
 void slip_set_tx_fn(uint8_t (*tx_fn)(uint8_t));
 
 /**
- * @brief Register flush function used by SLIP to flush TX buffer
+ * @brief Register flush function called after a complete frame is sent
  *
- * The function is called after a complete SLIP frame has been sent.
- * Optional - set to NULL for transports that don't require flushing.
+ * Optional — pass NULL for transports that do not need explicit flushing.
  *
  * @param flush_fn Function pointer with signature: void (*)(void)
  */
 void slip_set_flush_fn(void (*flush_fn)(void));
 
 /**
- * @brief Flush TX buffer
+ * @brief Send a SLIP-encoded frame
  *
- * Calls the registered flush function. This is automatically invoked by
- * slip_send_frame() after sending a complete frame.
+ * Wraps @p data with SLIP delimiters and byte-stuffing, then flushes.
+ * Only used by UART/USB transports — SDIO bypasses this and sends raw frames.
+ *
+ * @param data Pointer to payload
+ * @param size Payload length in bytes
+ * @return true on success, false if data is NULL
  */
-void slip_flush(void);
+bool slip_send_frame(const void *data, size_t size);
 
 /**
- * @brief Send SLIP frame delimiter
- */
-void slip_send_frame_delimiter(void);
-
-/**
- * @brief Send single byte with SLIP escaping
+ * @brief Feed one received byte into the SLIP decoder
  *
- * @param byte Byte to send
- */
-void slip_send_frame_data(uint8_t byte);
-
-/**
- * @brief Send buffer with SLIP escaping
+ * Call this from the transport RX interrupt for each received byte.
+ * The decoded frame is written into the buffer provided by slip_rearm().
  *
- * @param data Data buffer to send
- * @param size Size of data in bytes
- */
-void slip_send_frame_data_buf(const void *data, size_t size);
-
-/**
- * @brief Send complete SLIP frame
- *
- * @param data Data to send
- * @param size Size of data in bytes
- */
-void slip_send_frame(const void *data, size_t size);
-
-/**
- * @brief Process incoming byte through SLIP decoder
- *
- * This function should be called for each received byte.
- * Uses multi-buffering (configurable via SLIP_NUM_BUFFERS) for zero-copy operation.
- * Automatically switches to next available buffer when current frame completes.
- *
- * @param byte Incoming byte
+ * @param byte Incoming byte from the wire
  */
 void slip_recv_byte(uint8_t byte);
 
 /**
- * @brief Check if a complete frame has been received
+ * @brief Provide the next receive buffer to the SLIP decoder
  *
- * @return true if a complete frame is ready to process
+ * Call after frame_buffer_acquire() to hand the new buffer to the ISR.
+ * Pass NULL if no buffer is available; the ISR will discard incoming frames
+ * until slip_rearm() is called again with a valid buffer.
+ *
+ * @param buf Buffer pointer from frame_buffer_acquire(), or NULL
+ * @param cap Capacity of @p buf in bytes; the decoder marks the frame as an
+ *            error rather than overrunning this bound
  */
-bool slip_is_frame_complete(void);
-
-/**
- * @brief Check if a frame error occurred
- *
- * @return true if an error occurred (buffer overflow, invalid escape sequence)
- */
-bool slip_is_frame_error(void);
-
-/**
- * @brief Query frame state and get data/error info
- *
- * @return SLIP_STATE_COMPLETE, SLIP_STATE_ERROR, or SLIP_STATE_IDLE
- */
-int slip_get_frame_state(void);
-
-/**
- * @brief Get pointer to frame data (ZERO-COPY)
- *
- * Returns direct pointer to frame buffer - no memcpy needed!
- * Pointer remains valid until slip_recv_reset() is called.
- *
- * @param length Pointer to store the frame length (can be NULL)
- * @return Pointer to frame data buffer, or NULL if no frame available
- */
-const uint8_t *slip_get_frame_data(size_t *length);
-
-/**
- * @brief Reset receive state for next frame
- *
- * Switches to the other buffer and allows reception to continue.
- * Call this after processing a complete frame or to clear an error.
- */
-void slip_recv_reset(void);
+void slip_rearm(uint8_t *buf, size_t cap);
 
 #ifdef __cplusplus
 }

--- a/src/transport.c
+++ b/src/transport.c
@@ -11,6 +11,8 @@
 #include <esp-stub-lib/usb_otg.h>
 #include <esp-stub-lib/clock.h>
 #include <esp-stub-lib/rom_wrappers.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/sdio.h>
 #include "transport.h"
 #include "frame_buffer.h"
 #include "slip.h"
@@ -72,10 +74,75 @@ static const struct stub_transport_ops s_slip_ops = {
     .send_frame   = slip_send_frame,
 };
 
+/* ---- SDIO transport ops -------------------------------------------------- */
+/*
+ * SDIO bypasses SLIP entirely; the DMA writes a whole frame into the armed
+ * buffer and the ISR latches its length for stub_lib_sdio_take_rx_frame().
+ *
+ * The driver disarms its receive DMA not only after delivering a frame but
+ * also on no-frame paths (empty descriptor chain / TX_DSCR_EMPTY in
+ * sdio_slc_isr). Those disarms are invisible to frame_buffer, so recv_poll
+ * MUST re-arm whenever it finds no pending frame — otherwise the link
+ * silently dies. stub_lib_sdio_rearm() is a cheap no-op while still armed.
+ *
+ * Ordering constraint: stub_lib_sdio_rearm() fails while a received frame is
+ * still pending, so take_rx_frame() (which clears that state) must run first.
+ * On the no-frame path take_rx_frame() returned false, so nothing is pending
+ * and the re-arm is safe.
+ */
+
+static void sdio_arm(void)
+{
+    /* A NULL buffer means both frame buffers are occupied, which cannot
+     * happen under the lock-step + single early-ack protocol; if it ever
+     * did, RX would stall on the next frame (no silent corruption). */
+    stub_lib_sdio_rearm(frame_buffer_acquire(), FRAME_BUFFER_SIZE);
+}
+
+static const uint8_t *sdio_recv_poll(size_t *len, bool *error)
+{
+    *error = false;
+
+    enum frame_buffer_state state = frame_buffer_get_state();
+    if (state == FRAME_BUFFER_STATE_IDLE) {
+        size_t n;
+        if (!stub_lib_sdio_take_rx_frame(&n)) {
+            sdio_arm();
+            return NULL;
+        }
+        frame_buffer_mark_complete(n);   /* frame already DMA'd into proc buf */
+        state = frame_buffer_get_state();
+        sdio_arm();                      /* take done → switch to spare + arm  */
+    }
+    /* state != IDLE: a prior frame awaits release; its spare is already armed
+     * and may already hold an un-taken frame, so do NOT re-arm here. */
+    if (state == FRAME_BUFFER_STATE_ERROR) {
+        *error = true;
+        return NULL;
+    }
+    return frame_buffer_get_data(len);
+}
+
+static bool sdio_send_frame(const void *data, size_t len)
+{
+    return stub_lib_sdio_tx_frame(data, len) == STUB_LIB_OK;
+}
+
+static const struct stub_transport_ops s_sdio_ops = {
+    .recv_poll    = sdio_recv_poll,
+    .recv_release = frame_buffer_reset,
+    .send_frame   = sdio_send_frame,
+};
+
 /* ---- Detection & initialisation ------------------------------------------ */
 
 int stub_transport_detect(void)
 {
+    /* SDIO must be checked before USB: ROM may leave USB registers in an
+     * ambiguous state after an SDIO boot. */
+    if (stub_lib_sdio_is_active()) {
+        return TRANSPORT_SDIO;
+    }
     if (stub_lib_usb_otg_is_active()) {
         return TRANSPORT_USB_OTG;
     }
@@ -88,6 +155,12 @@ int stub_transport_detect(void)
 const struct stub_transport_ops *stub_transport_init(int transport)
 {
     switch (transport) {
+    case TRANSPORT_SDIO:
+        stub_lib_sdio_init();
+        /* Arm the first DMA receive buffer immediately after init. */
+        sdio_arm();
+        return &s_sdio_ops;
+
     case TRANSPORT_USB_OTG:
         stub_lib_usb_otg_rominit_intr_attach(USB_INTERRUPT_SOURCE, slip_recv_byte);
         slip_set_tx_fn(stub_lib_usb_otg_tx_one_char);

--- a/src/transport.c
+++ b/src/transport.c
@@ -5,28 +5,29 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <esp-stub-lib/uart.h>
 #include <esp-stub-lib/usb_serial_jtag.h>
 #include <esp-stub-lib/usb_otg.h>
 #include <esp-stub-lib/clock.h>
 #include <esp-stub-lib/rom_wrappers.h>
 #include "transport.h"
+#include "frame_buffer.h"
 #include "slip.h"
 
-#define USB_INTERRUPT_SOURCE 17
+#define USB_INTERRUPT_SOURCE  17
 #define UART_INTERRUPT_SOURCE 5
+
+/* ---- Interrupt handlers -------------------------------------------------- */
 
 void uart_rx_interrupt_handler()
 {
-    // This also resets the interrupt flags
     uint32_t intr_flags = stub_lib_uart_clear_intr_flags(UART_NUM_0);
 
     if ((intr_flags & UART_INTR_RXFIFO_FULL) || (intr_flags & UART_INTR_RXFIFO_TOUT)) {
         uint32_t count = stub_lib_uart_get_rxfifo_count(UART_NUM_0);
-
         for (uint32_t i = 0; i < count; ++i) {
-            uint8_t byte = stub_lib_uart_read_rxfifo_byte(UART_NUM_0);
-            slip_recv_byte(byte);
+            slip_recv_byte(stub_lib_uart_read_rxfifo_byte(UART_NUM_0));
         }
     }
 }
@@ -40,43 +41,81 @@ void usb_serial_jtag_rx_interrupt_handler()
     }
 }
 
+/* ---- SLIP-based transport ops (UART / USB-OTG / USB-Serial-JTAG) --------- */
+
+static void slip_do_rearm(void)
+{
+    slip_rearm(frame_buffer_acquire(), FRAME_BUFFER_SIZE);
+}
+
+static const uint8_t *slip_recv_poll(size_t *len, bool *error)
+{
+    *error = false;
+
+    /* get_state() selects the proc buffer; acquire() (inside slip_do_rearm)
+     * then switches the RX buffer to the spare; get_data() reads proc. */
+    enum frame_buffer_state state = frame_buffer_get_state();
+    if (state == FRAME_BUFFER_STATE_IDLE) {
+        return NULL;
+    }
+    slip_do_rearm();
+    if (state == FRAME_BUFFER_STATE_ERROR) {
+        *error = true;
+        return NULL;
+    }
+    return frame_buffer_get_data(len);
+}
+
+static const struct stub_transport_ops s_slip_ops = {
+    .recv_poll    = slip_recv_poll,
+    .recv_release = frame_buffer_reset,
+    .send_frame   = slip_send_frame,
+};
+
+/* ---- Detection & initialisation ------------------------------------------ */
+
 int stub_transport_detect(void)
 {
     if (stub_lib_usb_otg_is_active()) {
-        return STUB_TRANSPORT_USB_OTG;
+        return TRANSPORT_USB_OTG;
     }
     if (stub_lib_usb_serial_jtag_is_active()) {
-        return STUB_TRANSPORT_USB_SERIAL_JTAG;
+        return TRANSPORT_USB_SERIAL_JTAG;
     }
-    return STUB_TRANSPORT_UART;
+    return TRANSPORT_UART;
 }
 
-void stub_transport_init(int transport)
+const struct stub_transport_ops *stub_transport_init(int transport)
 {
     switch (transport) {
-    case STUB_TRANSPORT_USB_OTG:
+    case TRANSPORT_USB_OTG:
         stub_lib_usb_otg_rominit_intr_attach(USB_INTERRUPT_SOURCE, slip_recv_byte);
         slip_set_tx_fn(stub_lib_usb_otg_tx_one_char);
         slip_set_flush_fn(stub_lib_usb_otg_tx_flush);
-        return;
+        slip_do_rearm();
+        return &s_slip_ops;
 
-    case STUB_TRANSPORT_USB_SERIAL_JTAG:
+    case TRANSPORT_USB_SERIAL_JTAG:
         stub_lib_clock_disable_watchdogs();
-        stub_lib_usb_serial_jtag_rominit_intr_attach(USB_INTERRUPT_SOURCE, usb_serial_jtag_rx_interrupt_handler,
+        stub_lib_usb_serial_jtag_rominit_intr_attach(USB_INTERRUPT_SOURCE,
+                                                     usb_serial_jtag_rx_interrupt_handler,
                                                      USB_SERIAL_JTAG_OUT_RECV_PKT_INT_ENA);
         slip_set_tx_fn(stub_lib_usb_serial_jtag_tx_one_char);
         slip_set_flush_fn(stub_lib_usb_serial_jtag_tx_flush);
-        return;
+        slip_do_rearm();
+        return &s_slip_ops;
 
-    case STUB_TRANSPORT_UART:
+    case TRANSPORT_UART:
     default:
         // Wait for 10ms to ensure ROM has sent response to last command
         stub_lib_delay_us(10 * 1000);
         stub_lib_uart_wait_idle(UART_NUM_0);
-        stub_lib_uart_rominit_intr_attach(UART_NUM_0, UART_INTERRUPT_SOURCE, uart_rx_interrupt_handler,
+        stub_lib_uart_rominit_intr_attach(UART_NUM_0, UART_INTERRUPT_SOURCE,
+                                          uart_rx_interrupt_handler,
                                           UART_INTR_RXFIFO_FULL | UART_INTR_RXFIFO_TOUT);
         slip_set_tx_fn(stub_lib_uart_tx_one_char);
-        slip_set_flush_fn(NULL);  // UART doesn't need explicit flushing
-        return;
+        slip_set_flush_fn(NULL);
+        slip_do_rearm();
+        return &s_slip_ops;
     }
 }

--- a/src/transport.h
+++ b/src/transport.h
@@ -18,9 +18,41 @@ extern "C" {
  * @brief Supported transport types
  */
 enum stub_transport_type {
-    STUB_TRANSPORT_UART = 0,
-    STUB_TRANSPORT_USB_OTG = 1,
-    STUB_TRANSPORT_USB_SERIAL_JTAG = 2,
+    TRANSPORT_UART = 0,
+    TRANSPORT_USB_OTG = 1,
+    TRANSPORT_USB_SERIAL_JTAG = 2,
+};
+
+/**
+ * @brief Transport receive/transmit operations
+ *
+ * The receive buffering (single vs. double, DMA vs. byte ISR) is fully
+ * private to each transport implementation — callers only poll and release.
+ */
+struct stub_transport_ops {
+    /**
+     * Poll for the next complete received frame.
+     *
+     * @param len   Receives the frame length when a frame is returned.
+     * @param error Set true if the last reception failed (overflow / bad
+     *              escape); the frame pointer is NULL in that case.
+     * @return Pointer to the frame payload, or NULL when no frame is ready
+     *         or an error occurred.
+     *
+     * When a frame (or error) is returned the transport has already armed
+     * the spare receive buffer, so reception continues while the caller runs
+     * handle_command — required because commands such as FLASH_DATA send
+     * their response early and the host immediately streams the next frame.
+     */
+    const uint8_t *(*recv_poll)(size_t *len, bool *error);
+
+    /**
+     * Release the frame returned by the most recent recv_poll().
+     * Idempotent; never affects the buffer currently being received into.
+     */
+    void (*recv_release)(void);
+
+    bool (*send_frame)(const void *data, size_t len);
 };
 
 /**
@@ -34,7 +66,7 @@ int stub_transport_detect(void);
 /**
  * @brief Initialize the transport layer
  */
-void stub_transport_init(int transport);
+const struct stub_transport_ops *stub_transport_init(int transport);
 
 /**
  * @brief UART interrupt handler

--- a/src/transport.h
+++ b/src/transport.h
@@ -21,6 +21,7 @@ enum stub_transport_type {
     TRANSPORT_UART = 0,
     TRANSPORT_USB_OTG = 1,
     TRANSPORT_USB_SERIAL_JTAG = 2,
+    TRANSPORT_SDIO = 3,
 };
 
 /**

--- a/tools/compute_plugin_addrs.py
+++ b/tools/compute_plugin_addrs.py
@@ -15,20 +15,8 @@ import sys
 
 try:
     from elftools.elf.elffile import ELFFile
-    from elftools.elf.sections import SymbolTableSection
 except ImportError:
     raise SystemExit('pyelftools not found. Install with: pip install pyelftools')
-
-
-def get_symbol_addr(elf, name):
-    """Return the VMA of symbol *name*, or None if not found."""
-    for section in elf.iter_sections():
-        if not isinstance(section, SymbolTableSection):
-            continue
-        for sym in section.iter_symbols():
-            if sym.name == name and sym['st_value'] != 0:
-                return sym['st_value']
-    return None
 
 
 def align_up(value, alignment):
@@ -96,27 +84,7 @@ def main():
         # Place plugin BSS after both .data and .bss to avoid overlap
         next_bss_addr = align_up(max(data_end, bss_end), 4)
 
-        # Symbols forwarded to the plugin via PROVIDE in the linker script
-        slip_syms = [
-            'slip_send_frame',
-            'slip_recv_reset',
-            'slip_is_frame_complete',
-            'slip_get_frame_data',
-        ]
-
-        sym_addrs = {}
-        for name in slip_syms:
-            addr = get_symbol_addr(elf, name)
-            if addr is None:
-                sys.exit(f"ERROR: symbol '{name}' not found in base stub ELF")
-            sym_addrs[name] = addr
-
-    lines = [
-        f'set(SLIP_SEND_FRAME_ADDR         0x{sym_addrs["slip_send_frame"]:08X})',
-        f'set(SLIP_RECV_RESET_ADDR         0x{sym_addrs["slip_recv_reset"]:08X})',
-        f'set(SLIP_IS_FRAME_COMPLETE_ADDR  0x{sym_addrs["slip_is_frame_complete"]:08X})',
-        f'set(SLIP_GET_FRAME_DATA_ADDR     0x{sym_addrs["slip_get_frame_data"]:08X})',
-    ]
+    lines = []
 
     # Allocate addresses sequentially for each requested plugin.
     # If no --plugin arguments are given (legacy/first-pass invocation), fall

--- a/unittests/host/CMakeLists.txt
+++ b/unittests/host/CMakeLists.txt
@@ -117,18 +117,18 @@ add_host_test(TestSlip
     SOURCES
         TestSlip.c
         ../../src/slip.c
+        ../../src/frame_buffer.c
 )
 
-# TestNandPlugin — tests nand_plugin.c handlers using mocked nand, slip, and md5.
+# TestNandPlugin — tests nand_plugin.c handlers using mocked nand and md5.
 # Handlers return status codes; the dispatcher sends the primary response frame.
-# Only streaming post_process paths should call slip_send_frame().
+# Streaming post_process paths use a fake transport.
 add_executable(TestNandPlugin
     TestNandPlugin.c
     ../../src/nand_plugin.c
     ${UNITY_SOURCES}
     ${CMOCK_SOURCES}
     ${CMAKE_CURRENT_BINARY_DIR}/mocks/mock_nand.c
-    ${CMAKE_CURRENT_BINARY_DIR}/mocks/mock_slip.c
     ${CMAKE_CURRENT_BINARY_DIR}/mocks/mock_md5.c
 )
 

--- a/unittests/host/TestNandPlugin.c
+++ b/unittests/host/TestNandPlugin.c
@@ -17,20 +17,20 @@
  *
  * For nand_plugin_read_flash the handler registers resp->post_process; calling
  * resp.post_process(&fake_ctx) exercises the streaming loop (data packets + MD5).
- * Streaming frames from the post-process are still captured via the
- * slip_send_frame stub. See command_handler.c:s_send_response for the primary
- * response framing path used for all other handlers.
+ * Streaming frames from the post-process are captured through a fake transport.
+ * See command_handler.c:s_send_response for the primary response framing path
+ * used for all other handlers.
  */
 
 #include <stdint.h>
 #include <string.h>
 #include "unity.h"
 #include "mock_nand.h"
-#include "mock_slip.h"
 #include "mock_md5.h"
 #include "commands.h"
 #include "command_handler.h"
 #include "plugin_table.h"
+#include "transport.h"
 
 /* ---- Dummy plugin_table (required by nand_plugin.c's extern declaration) -- */
 plugin_cmd_handler_t plugin_table[PLUGIN_TABLE_SIZE];
@@ -71,60 +71,65 @@ static void reset_capture(void)
     s_frame_count   = 0;
 }
 
-/* CMock callback registered via slip_send_frame_StubWithCallback().
- * Captures only the first frame. */
-static void mock_slip_send_frame_cb(const void *data, size_t size, int num_calls)
+/* Captures only the first frame. */
+static bool fake_transport_send_frame(const void *data, size_t size)
 {
-    (void)num_calls;
     if (s_frame_count == 0 && size <= CAPTURED_FRAME_MAX) {
         memcpy(s_captured_frame, data, size);
         s_captured_size = size;
     }
     s_frame_count++;
+    return true;
 }
 
 /* ---- Callbacks for nand_plugin_read_flash -------------------------------- */
 
 /*
  * After the first data packet is sent, the handler checks for ACKs.
- * We simulate one ACK by returning true from slip_is_frame_complete on call 1+,
- * and returning a buffer with acked_data_size = 2048 from slip_get_frame_data.
+ * We simulate one ACK: the first poll returns no frame (before the first
+ * packet is sent), and every poll from the second on returns a 4-byte
+ * buffer holding acked_data_size.
  */
 static uint32_t s_read_flash_ack_size;
+static int s_read_flash_poll_calls;
 
-static bool slip_is_frame_complete_read_flash_cb(int num_calls)
+static const uint8_t *fake_transport_recv_poll(size_t *length, bool *error)
 {
-    /* Return true starting from the second check (after the first packet is sent) */
-    return num_calls >= 1;
-}
-
-static const uint8_t *slip_get_frame_data_read_flash_cb(size_t *length, int num_calls)
-{
-    (void)num_calls;
+    *error = false;
+    if (s_read_flash_poll_calls++ < 1) {
+        return NULL;
+    }
     if (length) {
         *length = sizeof(s_read_flash_ack_size);
     }
     return (const uint8_t *)&s_read_flash_ack_size;
 }
 
+static void fake_transport_recv_release(void)
+{
+}
+
+static const struct stub_transport_ops s_fake_transport = {
+    .recv_poll = fake_transport_recv_poll,
+    .recv_release = fake_transport_recv_release,
+    .send_frame = fake_transport_send_frame,
+};
+
 /* ---- Unity setUp / tearDown --------------------------------------------- */
 
 void setUp(void)
 {
     reset_capture();
+    s_read_flash_ack_size = 0;
+    s_read_flash_poll_calls = 0;
     mock_nand_Init();
-    mock_slip_Init();
     mock_md5_Init();
-    /* Register the frame capture callback for streaming-frame tests */
-    slip_send_frame_StubWithCallback(mock_slip_send_frame_cb);
 }
 
 void tearDown(void)
 {
     mock_nand_Verify();
     mock_nand_Destroy();
-    mock_slip_Verify();
-    mock_slip_Destroy();
     mock_md5_Verify();
     mock_md5_Destroy();
 }
@@ -567,16 +572,12 @@ void test_read_flash_success(void)
 
     /* Step (b): invoke post_process — exercises the streaming loop.
      *
-     * ACK loop setup:
-     *   - slip_recv_reset: ignore all calls
-     *   - slip_is_frame_complete: return false on call 0 (before packet sent),
-     *       true on call 1+ (after packet sent) — triggers ACK processing
-     *   - slip_get_frame_data: return a 4-byte buffer with acked_data_size = 2048
-     *       so the loop exits (acked_data_size >= read_size) */
+     * ACK loop setup (fake transport):
+     *   - recv_release: ignore all calls
+     *   - recv_poll: return no frame on call 0 (before packet sent), then a
+     *       4-byte buffer with acked_data_size = 2048 from call 1 on, so the
+     *       loop exits (acked_data_size >= read_size) */
     s_read_flash_ack_size = 2048;
-    slip_recv_reset_Ignore();
-    slip_is_frame_complete_StubWithCallback(slip_is_frame_complete_read_flash_cb);
-    slip_get_frame_data_StubWithCallback(slip_get_frame_data_read_flash_cb);
 
     /* MD5 calls */
     stub_lib_md5_init_Ignore();
@@ -585,8 +586,9 @@ void test_read_flash_success(void)
 
     stub_target_nand_read_page_IgnoreAndReturn(0);
 
-    /* Fake cmd_ctx — post_process does not use ctx fields */
-    struct cmd_ctx fake_ctx = {0};
+    struct cmd_ctx fake_ctx = {
+        .transport = &s_fake_transport,
+    };
     int post_rc = resp.post_process(&fake_ctx);
 
     /* Streaming frames:

--- a/unittests/host/TestSlip.c
+++ b/unittests/host/TestSlip.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -8,202 +8,149 @@
 #include "mock_rom_wrappers.h"
 #include "mock_uart.h"
 #include "slip.h"
+#include "frame_buffer.h"
 #include <string.h>
 
-/* Test setup and teardown */
 void setUp(void)
 {
-    /* Initialize mocks */
     mock_rom_wrappers_Init();
     mock_uart_Init();
+
+    /* Hand the SLIP decoder a fresh receive buffer — the ISR refuses to
+     * start a frame without one. frame_buffer state persists across tests
+     * via static state, but every RX test that marks a frame resets it before
+     * returning, so acquire() yields a clean buffer here. */
+    slip_rearm(frame_buffer_acquire(), FRAME_BUFFER_SIZE);
 }
 
 void tearDown(void)
 {
-    /* Clean up mocks */
     mock_rom_wrappers_Verify();
     mock_rom_wrappers_Destroy();
     mock_uart_Verify();
     mock_uart_Destroy();
 }
 
-/* Test cases */
-void test_slip_send_frame_delimiter(void)
-{
-    /* Expect uart_tx_one_char to be called with SLIP_END (0xC0) */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xC0, 0);
-
-    /* Call the function under test */
-    slip_send_frame_delimiter();
-}
-
-void test_slip_send_frame_data_normal_byte(void)
-{
-    /* Expect uart_tx_one_char to be called with normal byte */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0x55, 0);
-
-    /* Call the function under test */
-    slip_send_frame_data(0x55);
-}
-
-void test_slip_send_frame_data_end_escape(void)
-{
-    /* Expect uart_tx_one_char to be called twice: SLIP_ESC then SLIP_ESC_END */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* SLIP_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDC, 0); /* SLIP_ESC_END */
-
-    /* Call the function under test with SLIP_END byte */
-    slip_send_frame_data(0xC0);
-}
-
-void test_slip_send_frame_data_esc_escape(void)
-{
-    /* Expect uart_tx_one_char to be called twice: SLIP_ESC then SLIP_ESC_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* SLIP_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDD, 0); /* SLIP_ESC_ESC */
-
-    /* Call the function under test with SLIP_ESC byte */
-    slip_send_frame_data(0xDB);
-}
-
-void test_slip_send_frame_data_buf_normal(void)
-{
-    uint8_t test_data[] = {0x01, 0x02, 0x03};
-
-    /* Expect uart_tx_one_char to be called for each byte */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0x01, 0);
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0x02, 0);
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0x03, 0);
-
-    /* Call the function under test */
-    slip_send_frame_data_buf(test_data, sizeof(test_data));
-}
-
-void test_slip_send_frame_data_buf_with_escapes(void)
-{
-    uint8_t test_data[] = {0x01, 0xC0, 0xDB, 0x02};
-
-    /* Expect uart_tx_one_char to be called for each byte with proper escaping */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0x01, 0);
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* SLIP_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDC, 0); /* SLIP_ESC_END */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* SLIP_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDD, 0); /* SLIP_ESC_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0x02, 0);
-
-    /* Call the function under test */
-    slip_send_frame_data_buf(test_data, sizeof(test_data));
-}
-
-void test_slip_send_frame_data_buf_null_pointer(void)
-{
-    /* Should not call uart_tx_one_char when data is NULL */
-
-    /* Call the function under test with NULL data */
-    slip_send_frame_data_buf(NULL, 10);
-}
+/* ---- TX: slip_send_frame ------------------------------------------------- */
 
 void test_slip_send_frame_complete(void)
 {
     uint8_t test_data[] = {0x01, 0xC0, 0xDB, 0x02};
 
-    /* Expect complete frame: SLIP_END + data + SLIP_END */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xC0, 0); /* SLIP_END */
+    /* SLIP_END + escaped payload + SLIP_END */
+    stub_lib_uart_tx_one_char_ExpectAndReturn(0xC0, 0); /* SLIP_END open */
     stub_lib_uart_tx_one_char_ExpectAndReturn(0x01, 0);
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* SLIP_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDC, 0); /* SLIP_ESC_END */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* SLIP_ESC */
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDD, 0); /* SLIP_ESC_ESC */
+    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* ESC */
+    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDC, 0); /* ESC_END */
+    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDB, 0); /* ESC */
+    stub_lib_uart_tx_one_char_ExpectAndReturn(0xDD, 0); /* ESC_ESC */
     stub_lib_uart_tx_one_char_ExpectAndReturn(0x02, 0);
-    stub_lib_uart_tx_one_char_ExpectAndReturn(0xC0, 0); /* SLIP_END */
+    stub_lib_uart_tx_one_char_ExpectAndReturn(0xC0, 0); /* SLIP_END close */
 
-    /* Call the function under test */
-    slip_send_frame(test_data, sizeof(test_data));
+    TEST_ASSERT_TRUE(slip_send_frame(test_data, sizeof(test_data)));
 }
 
 void test_slip_send_frame_null_data(void)
 {
-    /* Should not call uart_tx_one_char when data is NULL */
-
-    /* Call the function under test with NULL data */
-    slip_send_frame(NULL, 10);
+    /* No bytes should be sent; function must return false */
+    TEST_ASSERT_FALSE(slip_send_frame(NULL, 10));
 }
+
+/* ---- RX: slip_recv_byte + frame_buffer ----------------------------------- */
+/*
+ * slip_recv_byte decodes SLIP framing and writes payload into frame_buffer.
+ * Tests exercise the state machine and verify frame_buffer state afterwards.
+ */
 
 void test_slip_recv_byte_no_frame_start(void)
 {
-    /* Test receiving non-SLIP_END byte when not in frame */
-    /* This should not cause any state change */
-
-    /* Call the function under test */
+    /* Non-SLIP_END byte before any frame — no frame should start */
     slip_recv_byte(0x55);
+    TEST_ASSERT_EQUAL_INT(FRAME_BUFFER_STATE_IDLE, frame_buffer_get_state());
 }
 
-void test_slip_recv_byte_frame_start(void)
+void test_slip_recv_byte_empty_frame_discarded(void)
 {
-    /* Test receiving SLIP_END to start frame */
-    /* This should change state to STATE_IN_FRAME */
-
-    /* Call the function under test */
+    /* Two consecutive SLIP_ENDs without payload — frame_buffer_mark_complete
+     * ignores zero-length frames, so state stays IDLE */
     slip_recv_byte(0xC0);
+    slip_recv_byte(0xC0);
+    TEST_ASSERT_EQUAL_INT(FRAME_BUFFER_STATE_IDLE, frame_buffer_get_state());
+    frame_buffer_reset();
 }
 
-void test_slip_recv_byte_frame_end(void)
+void test_slip_recv_byte_complete_frame(void)
 {
-    /* First start a frame */
+    uint8_t expected[] = {0x01, 0x02, 0x03};
+
+    slip_recv_byte(0xC0);
+    slip_recv_byte(0x01);
+    slip_recv_byte(0x02);
+    slip_recv_byte(0x03);
     slip_recv_byte(0xC0);
 
-    /* Then end it */
-    slip_recv_byte(0xC0);
+    TEST_ASSERT_EQUAL_INT(FRAME_BUFFER_STATE_COMPLETE, frame_buffer_get_state());
+
+    size_t len;
+    const uint8_t *data = frame_buffer_get_data(&len);
+    TEST_ASSERT_EQUAL_size_t(sizeof(expected), len);
+    TEST_ASSERT_EQUAL_MEMORY(expected, data, len);
+    frame_buffer_reset();
 }
 
-void test_slip_recv_byte_escape_sequence_end(void)
+void test_slip_recv_byte_escape_end(void)
 {
-    /* Start frame */
     slip_recv_byte(0xC0);
+    slip_recv_byte(0xDB); /* ESC */
+    slip_recv_byte(0xDC); /* ESC_END → 0xC0 */
+    slip_recv_byte(0xC0); /* frame end */
 
-    /* Send escape sequence for SLIP_END */
-    slip_recv_byte(0xDB); /* SLIP_ESC */
-    slip_recv_byte(0xDC); /* SLIP_ESC_END - should become SLIP_END */
+    TEST_ASSERT_EQUAL_INT(FRAME_BUFFER_STATE_COMPLETE, frame_buffer_get_state());
+
+    size_t len;
+    const uint8_t *data = frame_buffer_get_data(&len);
+    TEST_ASSERT_EQUAL_size_t(1, len);
+    TEST_ASSERT_EQUAL_UINT8(0xC0, data[0]);
+    frame_buffer_reset();
 }
 
-void test_slip_recv_byte_escape_sequence_esc(void)
+void test_slip_recv_byte_escape_esc(void)
 {
-    /* Start frame */
     slip_recv_byte(0xC0);
+    slip_recv_byte(0xDB); /* ESC */
+    slip_recv_byte(0xDD); /* ESC_ESC → 0xDB */
+    slip_recv_byte(0xC0); /* frame end */
 
-    /* Send escape sequence for SLIP_ESC */
-    slip_recv_byte(0xDB); /* SLIP_ESC */
-    slip_recv_byte(0xDD); /* SLIP_ESC_ESC - should become SLIP_ESC */
+    TEST_ASSERT_EQUAL_INT(FRAME_BUFFER_STATE_COMPLETE, frame_buffer_get_state());
+
+    size_t len;
+    const uint8_t *data = frame_buffer_get_data(&len);
+    TEST_ASSERT_EQUAL_size_t(1, len);
+    TEST_ASSERT_EQUAL_UINT8(0xDB, data[0]);
+    frame_buffer_reset();
 }
 
 void test_slip_recv_byte_invalid_escape(void)
 {
-    /* Start frame */
     slip_recv_byte(0xC0);
+    slip_recv_byte(0xDB); /* ESC */
+    slip_recv_byte(0xFF); /* invalid — frame becomes an error */
 
-    /* Send invalid escape sequence */
-    slip_recv_byte(0xDB); /* SLIP_ESC */
-    slip_recv_byte(0xFF); /* Invalid escape - should be dropped */
+    TEST_ASSERT_EQUAL_INT(FRAME_BUFFER_STATE_ERROR, frame_buffer_get_state());
+    frame_buffer_reset();
 }
 
 int main(void)
 {
     UnityBegin(__FILE__);
 
-    RUN_TEST(test_slip_send_frame_delimiter);
-    RUN_TEST(test_slip_send_frame_data_normal_byte);
-    RUN_TEST(test_slip_send_frame_data_end_escape);
-    RUN_TEST(test_slip_send_frame_data_esc_escape);
-    RUN_TEST(test_slip_send_frame_data_buf_normal);
-    RUN_TEST(test_slip_send_frame_data_buf_with_escapes);
-    RUN_TEST(test_slip_send_frame_data_buf_null_pointer);
     RUN_TEST(test_slip_send_frame_complete);
     RUN_TEST(test_slip_send_frame_null_data);
     RUN_TEST(test_slip_recv_byte_no_frame_start);
-    RUN_TEST(test_slip_recv_byte_frame_start);
-    RUN_TEST(test_slip_recv_byte_frame_end);
-    RUN_TEST(test_slip_recv_byte_escape_sequence_end);
-    RUN_TEST(test_slip_recv_byte_escape_sequence_esc);
+    RUN_TEST(test_slip_recv_byte_empty_frame_discarded);
+    RUN_TEST(test_slip_recv_byte_complete_frame);
+    RUN_TEST(test_slip_recv_byte_escape_end);
+    RUN_TEST(test_slip_recv_byte_escape_esc);
     RUN_TEST(test_slip_recv_byte_invalid_escape);
 
     return UnityEnd();


### PR DESCRIPTION
# MR Description

## Summary

- Refactors RX handling into a shared double-buffered `frame_buffer` layer and a transport ops API.
- Adds SDIO as a raw-frame transport alongside existing SLIP-based UART/USB transports.
- Keeps ESP8266 `miniz` size optimization local to `miniz_obj`, saving 3193 bytes of `.data`.

## Flow

```mermaid
flowchart LR
    Host[Host tool] --> Transport{Transport}
    Transport -->|UART / USB| SLIP[SLIP decode/encode]
    Transport -->|SDIO| Raw[Raw frame]
    SLIP --> Buffer[frame_buffer]
    Raw --> Buffer
    Buffer --> Handler[Command handler]
    Handler --> Plugin[Optional plugin]
    Handler --> Reply[Transport send_frame]
    Plugin --> Reply
```

## Validation

- SDIO path tested with ESP32-C6 and ESP32-C5 targets.
- Esptool pipeline passed.
