### PR TITLE
refactor: compute plugin load addresses at build time (ESPTOOL-1323)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,9 +122,7 @@ source ./tools/export_toolchains.sh
 **Build Time**: ~10-15 seconds for all 14 chips (note: cmake defines 15 total targets, but build script excludes esp32h21)
 **Output**: Creates `build-{chip}/` directories for each chip with ELF and JSON files
 
-This script uses a **two-pass build** process:
-1. **Pass 1 (all chips)**: Configures CMake with `--fresh`, builds base stub ELF
-2. **Pass 2 (non-ESP8266, non-ESP32)**: Re-configures CMake so `compute_plugin_addrs.py` generates `plugin_addrs.cmake` from the base ELF, then builds the plugin ELF and regenerates JSON
+This script builds each chip with `cmake --fresh` followed by `ninja`. For plugin-capable chips (all except esp8266/esp32), CMake also computes the plugin load addresses from the base stub, links the plugin, and embeds it in the JSON.
 
 ## Pre-commit Hooks and Validation
 
@@ -253,7 +251,7 @@ The repository uses pre-commit.ci for automated PR checks. It runs all pre-commi
 - `export_toolchains.sh` - Adds toolchains to PATH (must be sourced)
 - `elf2json.py` - Converts ELF binaries to JSON format for esptool
 - `compare_sizes.py` - Compares stub segment sizes between two builds; used by CI to post size reports on PRs
-- `compute_plugin_addrs.py` - Computes plugin load addresses from base stub ELF (used in two-pass build)
+- `compute_plugin_addrs.py` - Emits a linker fragment with plugin load addresses computed from the base stub ELF
 - `install_all_chips.sh` - Copies built JSON files to esptool directory (requires ESPTOOL_STUBS_DIR env var)
 
 **`esp-stub-lib/`** (submodule)
@@ -287,7 +285,7 @@ The repository uses pre-commit.ci for automated PR checks. It runs all pre-commi
 - **CMake target configuration**: `cmake/esp-targets.cmake` determines toolchain and compiler flags based on TARGET_CHIP
 - **Linker scripts**: Each chip has a specific linker script in `src/ld/{chip}.ld`
 - **Post-build processing**: `tools/elf2json.py` requires pyelftools; called automatically after build
-- **Two-pass plugin build**: Chips with plugin support (all except esp8266 and esp32) use a two-pass build: Pass 1 builds the base stub ELF, Pass 2 computes plugin addresses and builds the plugin ELF
+- **Plugin build**: Chips with plugin support (all except esp8266 and esp32) build the base stub, compute plugin load addresses from it via a build-time custom command, link the plugin, and embed it in the JSON
 - **Chip support**: cmake defines 15 chips (esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4-rev1, esp32p4, esp32s31, esp8266), but build_all_chips.sh only builds 14 (excludes esp32h21)
 
 ## Common Issues and Workarounds

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,11 +91,11 @@ The stub supports runtime-loadable plugins that extend the command set. Plugins 
 
 Command handlers and plugin post-process callbacks receive a `struct cmd_ctx` that includes the selected transport operations. Streaming code should send data and poll ACKs through `ctx->transport`, so plugin code stays independent of whether the host is using SLIP-based UART/USB or raw SDIO.
 
-For chips that support a plugin (currently ESP32-S3 with the NAND plugin), the build uses a **two-pass** process:
+For chips that support a plugin (currently ESP32-S3 with the NAND plugin), the plugin's load address is derived from the base stub, so the build proceeds as a dependency chain:
 
-1. Build the base stub ELF (Pass 1).
-2. `tools/compute_plugin_addrs.py` computes plugin load addresses from the base ELF sizes.
-3. Build the plugin ELF linked at those addresses (Pass 2).
+1. Build the base stub ELF.
+2. `tools/compute_plugin_addrs.py` reads the base ELF sizes and emits a linker fragment with the plugin load addresses.
+3. Build the plugin ELF, which pulls in that fragment via `-T` and relinks automatically whenever the base stub changes.
 4. `tools/elf2json.py` embeds the plugin into the JSON stub file.
 
 For the full guide including how to add a new plugin, see [Plugin System](plugin-system.md).

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -134,5 +134,5 @@ Create a pull request and edit the automatically created draft release on the [r
 | `tools/export_toolchains.sh` | Add toolchain directories to `PATH` (must be sourced) |
 | `tools/elf2json.py` | Convert ELF binary to JSON format for esptool; embeds plugin data when `--plugin` is specified |
 | `tools/compare_sizes.py` | Compare stub segment sizes between two builds; used by CI to post size reports on PRs |
-| `tools/compute_plugin_addrs.py` | Compute plugin load addresses from base stub ELF (used in two-pass build) |
+| `tools/compute_plugin_addrs.py` | Emit a linker fragment with plugin load addresses computed from the base stub ELF |
 | `tools/install_all_chips.sh` | Copy built JSON files into an esptool installation |

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -86,32 +86,38 @@ After startup, plugin opcodes use the same command dispatcher and transport oper
 
 On Xtensa cores (ESP32-S2, ESP32-S3), IRAM only supports 32-bit stores. Writing non-4-byte-aligned data to IRAM causes a `LoadStoreError` exception (EXCCAUSE=3). `elf2json.py` automatically pads the plugin `.text` to a 4-byte boundary before embedding it in the JSON file.
 
-## Two-Pass Build
+## Build
 
-Because the plugin must be linked at fixed addresses that depend on the size of the base stub, the build uses two passes:
+A plugin must be linked at a fixed address immediately after the base stub (and after any earlier plugins), so its load address depends on the base stub's `.text`/`.data`/`.bss` sizes. Those sizes are only known once the base stub is linked, so the address is computed at **build time**, after the base stub:
 
 ```
-Pass 1: cmake/ninja → base stub ELF
+stub-<chip>.elf                          (base stub linked)
             │
             ▼
 tools/compute_plugin_addrs.py
-  Reads base stub ELF, extracts .text, .data, and .bss sizes,
-  computes <NAME>_PLUGIN_TEXT_ADDR and <NAME>_PLUGIN_BSS_ADDR
+  Reads the base ELF .text/.data/.bss sizes (plus any preceding
+  plugin ELFs passed via --after) and writes a linker fragment
+  <name>_plugin_addrs.ld:  PLUGIN_TEXT_ADDR / PLUGIN_BSS_ADDR
             │
             ▼
-Pass 2: cmake/ninja → plugin ELF (linked at computed addresses)
+stub-<chip>-<name>-plugin.elf
+  Linked with  -T <name>_plugin_addrs.ld  -T <name>_plugin.ld.
+  A LINK_DEPENDS on the fragment relinks the plugin whenever the
+  base stub's size changes.
             │
             ▼
 tools/elf2json.py
-  Converts base stub ELF to JSON, embeds plugin .text and
-  .bss metadata as an additional section in the JSON file
+  Converts the base stub ELF to JSON and embeds each plugin's
+  .text and .bss metadata under the "plugins" key.
 ```
+
+The generated fragment replaces the older `-Wl,--defsym` approach: `compute_plugin_addrs.py` emits linker-script symbol assignments that the plugin linker script consumes in its `MEMORY` block. Multiple plugins **stack** — each plugin's fragment is computed from the base stub plus every preceding plugin ELF (`--after`).
 
 ### Key Tool Files
 
 | File | Purpose |
 |---|---|
-| `tools/compute_plugin_addrs.py` | Extracts base ELF sizes and computes one or more plugin load addresses |
+| `tools/compute_plugin_addrs.py` | Reads base (+ preceding plugin) ELF sizes and emits a `<name>_plugin_addrs.ld` fragment defining `PLUGIN_TEXT_ADDR`/`PLUGIN_BSS_ADDR` |
 | `tools/elf2json.py` | Converts ELF to JSON; embeds plugin `.text` and `.bss` size |
 | `src/plugin_table.h` | FPT ABI constants and `plugin_cmd_handler_t` typedef |
 | `src/command_handler.c` | Opcode dispatch to FPT |
@@ -164,7 +170,7 @@ int spi_ram_plugin_read(uint8_t command, const uint8_t *data,
 
 ### Step 3 — Create `src/ld/spi_ram_plugin.ld`
 
-Follow the pattern of `src/ld/nand_plugin.ld`. CMake supplies `PLUGIN_TEXT_ADDR` and `PLUGIN_BSS_ADDR` via `-Wl,--defsym`. Reuse `common.ld` for section layout; override the entry point and `EXTERN` every handler symbol:
+Follow the pattern of `src/ld/nand_plugin.ld`. `PLUGIN_TEXT_ADDR` and `PLUGIN_BSS_ADDR` come from the generated `<name>_plugin_addrs.ld` fragment (pulled in via `-T`). Reuse `common.ld` for section layout; override the entry point and `EXTERN` every handler symbol:
 
 ```ld
 MEMORY {
@@ -185,9 +191,9 @@ ASSERT(SIZEOF(.data) == 0, "Plugin must not have initialized .data — use BSS i
 
 Implement target-specific functions (e.g., `src/target/esp32s3/src/spi_ram.c`) following the same pattern as `nand.c` and `spi_nand.c`.
 
-### Step 5 — Update `CMakeLists.txt`
+### Step 5 — Update `src/CMakeLists.txt`
 
-Add detection of the new HAL file (analogous to `_NAND_C`), then call `stub_add_plugin()` with the plugin sources and computed load-address variable names:
+Add detection of the new HAL file (analogous to `_NAND_C`), then call `stub_add_plugin()` with the plugin sources and linker script. The macro derives the target name, generates the `<name>_plugin_addrs.ld` fragment, wires the build-time dependencies, and stacks the plugin after any earlier ones — no addresses to specify by hand:
 
 ```cmake
 set(_SPI_RAM_C ${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/src/spi_ram.c)
@@ -199,11 +205,11 @@ if(EXISTS "${_SPI_RAM_C}")
             spi_ram_plugin.c
             ${_SPI_RAM_C}
         LINKER_SCRIPT ${LINKER_SCRIPTS_DIR}/spi_ram_plugin.ld
-        TEXT_ADDR     SPI_RAM_PLUGIN_TEXT_ADDR
-        BSS_ADDR      SPI_RAM_PLUGIN_BSS_ADDR
     )
 endif()
 ```
+
+Plugins load in the order `stub_add_plugin()` is called: the first is placed right after the base stub and each subsequent plugin stacks after the previous one.
 
 ### Step 6 — Update `tools/elf2json.py`
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,70 +14,80 @@ target_link_options(${TARGET_NAME} PRIVATE
 
 target_link_libraries(${TARGET_NAME} PRIVATE esp-stub-lib)
 
-# Post-build: generate base JSON (no plugin yet)
-set(BASE_ELF ${CMAKE_BINARY_DIR}/src/${TARGET_NAME}${CMAKE_EXECUTABLE_SUFFIX_C})
-set(BASE_JSON ${CMAKE_BINARY_DIR}/${TARGET_CHIP}.json)
+# Base stub ELF — referenced as a dependency by the plugin-address and JSON
+# custom commands below.
+set(BASE_ELF $<TARGET_FILE:${TARGET_NAME}>)
+set(STUB_JSON ${CMAKE_BINARY_DIR}/${TARGET_CHIP}.json)
 
-# For plugin-capable chips the base POST_BUILD writes to .base.json; the
-# combined POST_BUILD (attached to the last plugin target) then writes the
-# final .json.  For esp8266/esp32 (no plugin support) we write directly to
-# .json because the combined step never runs for those chips.
-if(TARGET_CHIP STREQUAL "esp8266" OR TARGET_CHIP STREQUAL "esp32")
-    set(BASE_ONLY_JSON ${BASE_JSON})
-else()
-    set(BASE_ONLY_JSON ${CMAKE_BINARY_DIR}/${TARGET_CHIP}.base.json)
-endif()
+# ---------------------------------------------------------------------------
+# Plugins
+#
+# A plugin must be linked at a fixed address that sits right after the base
+# stub (and after any earlier plugins).  Those addresses are only known once
+# the base stub is linked, so they are computed at build time:
+#
+#   stub ELF ─► compute_plugin_addrs.py ─► <name>_plugin_addrs.ld ─► plugin ELF ─► JSON
+#
+# compute_plugin_addrs.py emits a linker fragment (PLUGIN_TEXT_ADDR /
+# PLUGIN_BSS_ADDR) that the plugin's linker script pulls in via -T.  The plugin
+# link gains a LINK_DEPENDS on that fragment, so it relinks whenever the base
+# stub's size changes.  Plugins stack: each plugin's fragment depends on the
+# base stub plus every preceding plugin ELF (passed via --after).
+#
+# To add a plugin: drop in its sources + linker script and call
+# stub_add_plugin() following the NAND example below.
+# ---------------------------------------------------------------------------
 
-add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-    COMMAND ${CMAKE_SOURCE_DIR}/tools/elf2json.py ${BASE_ELF} ${BASE_ONLY_JSON}
-    COMMENT "Generating base stub JSON"
-)
+# Populated by stub_add_plugin(); empty when no plugin applies, which collapses
+# the JSON step (below) to the same plain `elf2json.py <stub> <chip>.json` used
+# by esp8266/esp32.
+#   _plugin_json_args : --plugin <name> <elf> ... fed to elf2json.py
+#   _plugin_elfs      : plugin ELF files in load order — read inside the macro
+#                       (= earlier plugins, for --after) and after all calls
+#                       (= every plugin, for the JSON dependency)
+set(_plugin_json_args "")
+set(_plugin_elfs      "")
 
-# ---- Two-pass plugin build (all chips except ESP8266 and ESP32) -----------
-#
-# Plugin addresses depend on the base stub's .text/.data sizes, which are only
-# known after the first build.  On a fresh checkout:
-#   1. cmake + ninja  →  builds base stub, creates plugin_addrs.cmake
-#   2. cmake + ninja  →  configures and builds the plugin(s), regenerates JSON
-#      with all plugin data embedded
-#
-# To add a new plugin, define it below following the NAND pattern:
-#   1. Set _<NAME>_C to the target HAL source file path.
-#   2. Call stub_add_plugin() with the plugin parameters.
-#
 if(NOT TARGET_CHIP STREQUAL "esp8266" AND NOT TARGET_CHIP STREQUAL "esp32")
-    set(PLUGIN_ADDRS_FILE ${CMAKE_BINARY_DIR}/plugin_addrs.cmake)
-    set(ESP_STUB_LIB_DIR  ${CMAKE_SOURCE_DIR}/esp-stub-lib)
-
-    # Accumulates "--plugin name elf" pairs for the final elf2json.py invocation
-    set(_PLUGIN_ELF2JSON_ARGS "")
-    # Accumulates plugin ELF targets so the base-stub JSON command can depend on them
-    set(_PLUGIN_TARGETS "")
+    set(ESP_STUB_LIB_DIR ${CMAKE_SOURCE_DIR}/esp-stub-lib)
 
     # ---- Reusable macro: stub_add_plugin ------------------------------------
     # Usage:
     #   stub_add_plugin(
-    #       NAME        <plugin_name>          # lowercase, e.g. "nand"
-    #       SOURCES     <src1> [<src2> ...]    # plugin-specific C sources
+    #       NAME          <plugin_name>          # lowercase, e.g. "nand"
+    #       SOURCES       <src1> [<src2> ...]    # plugin-specific C sources
     #       LINKER_SCRIPT <path/to/plugin.ld>
-    #       TEXT_ADDR   <cmake_var_name>       # e.g. NAND_PLUGIN_TEXT_ADDR
-    #       BSS_ADDR    <cmake_var_name>       # e.g. NAND_PLUGIN_BSS_ADDR
     #   )
     macro(stub_add_plugin)
-        cmake_parse_arguments(_PA "" "NAME;LINKER_SCRIPT;TEXT_ADDR;BSS_ADDR" "SOURCES" ${ARGN})
+        cmake_parse_arguments(_PA "" "NAME;LINKER_SCRIPT" "SOURCES" ${ARGN})
 
-        string(TOUPPER "${_PA_NAME}" _PA_NAME_UPPER)
-        set(_plugin_target stub-${TARGET_CHIP}-${_PA_NAME}-plugin)
-        set(_plugin_elf    ${CMAKE_BINARY_DIR}/src/${_plugin_target}${CMAKE_EXECUTABLE_SUFFIX_C})
+        set(_plugin_target   stub-${TARGET_CHIP}-${_PA_NAME}-plugin)
+        set(_plugin_elf      $<TARGET_FILE:${_plugin_target}>)
+        set(_plugin_addrs_ld ${CMAKE_BINARY_DIR}/${_PA_NAME}_plugin_addrs.ld)
 
-        # Build the plugin by compiling only the required source files
-        # directly. Do NOT link against esp-stub-lib to avoid inheriting
-        # its -Wl,--whole-archive flag, which would drag every object from
-        # every static library into the tiny plugin binary.
-        add_executable(${_plugin_target}
-            ${_PA_SOURCES}
+        # Build-time address computation: stack this plugin after the base stub
+        # and any earlier plugins.  _plugin_elfs holds only those earlier plugins
+        # here — this plugin's own ELF is appended below, after it is read.
+        set(_after_args "")
+        foreach(_prev ${_plugin_elfs})
+            list(APPEND _after_args --after ${_prev})
+        endforeach()
+
+        add_custom_command(
+            OUTPUT  ${_plugin_addrs_ld}
+            COMMAND ${CMAKE_SOURCE_DIR}/tools/compute_plugin_addrs.py
+                    ${BASE_ELF} ${_plugin_addrs_ld} ${_after_args}
+            DEPENDS ${BASE_ELF} ${_plugin_elfs}
+                    ${CMAKE_SOURCE_DIR}/tools/compute_plugin_addrs.py
+            COMMENT "Computing ${_PA_NAME} plugin load address"
+            VERBATIM
         )
-        add_dependencies(${_plugin_target} ${TARGET_NAME})
+        add_custom_target(${_plugin_target}-addrs DEPENDS ${_plugin_addrs_ld})
+
+        # Build the plugin from its own sources only.  Do NOT link esp-stub-lib:
+        # its -Wl,--whole-archive would drag every object from every static
+        # library into the tiny plugin binary.
+        add_executable(${_plugin_target} ${_PA_SOURCES})
 
         target_include_directories(${_plugin_target} PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}
@@ -87,7 +97,7 @@ if(NOT TARGET_CHIP STREQUAL "esp8266" AND NOT TARGET_CHIP STREQUAL "esp32")
             ${ESP_STUB_LIB_DIR}/src/target/base/include
         )
 
-        # Collect all ROM LD scripts for this chip (symbol resolution only)
+        # Collect ROM LD scripts for this chip (symbol resolution only).
         file(GLOB _rom_ld_scripts
             "${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/ld/*.rom.ld"
             "${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/ld/*.rom.*.ld"
@@ -97,96 +107,58 @@ if(NOT TARGET_CHIP STREQUAL "esp8266" AND NOT TARGET_CHIP STREQUAL "esp32")
             list(APPEND _rom_ld_flags "-T${_s}")
         endforeach()
 
+        # Links with the global --gc-sections; handlers reachable only through
+        # the FPT are rooted by EXTERN() in the plugin linker script.
         target_link_options(${_plugin_target} PRIVATE
             -L${LINKER_SCRIPTS_DIR}
+            # Generated fragment first: defines PLUGIN_TEXT_ADDR / PLUGIN_BSS_ADDR
+            # used by the plugin linker script's MEMORY block.
+            "-T${_plugin_addrs_ld}"
             "-T${_PA_LINKER_SCRIPT}"
-            -Wl,--defsym,PLUGIN_TEXT_ADDR=${${_PA_TEXT_ADDR}}
-            -Wl,--defsym,PLUGIN_BSS_ADDR=${${_PA_BSS_ADDR}}
             -Wl,-Map=${CMAKE_BINARY_DIR}/${_plugin_target}.map
             ${_rom_ld_flags}
         )
 
-        # Accumulate this plugin's --plugin argument for elf2json.py
-        list(APPEND _PLUGIN_ELF2JSON_ARGS "--plugin" "${_PA_NAME}" "${_plugin_elf}")
-        list(APPEND _PLUGIN_TARGETS "${_plugin_target}")
+        # Build after the base stub (its load address comes from the linked base
+        # stub, and with LTO the base must be built first) and after the address
+        # fragment; relink whenever that fragment changes.
+        add_dependencies(${_plugin_target} ${TARGET_NAME} ${_plugin_target}-addrs)
+        set_target_properties(${_plugin_target} PROPERTIES LINK_DEPENDS ${_plugin_addrs_ld})
+
+        # Record this plugin: its --plugin arg for the JSON step, and its ELF
+        # (which the JSON depends on, and which later plugins stack after).
+        list(APPEND _plugin_json_args --plugin ${_PA_NAME} ${_plugin_elf})
+        list(APPEND _plugin_elfs      ${_plugin_elf})
     endmacro()
 
-    # ---- Discover which plugins apply to this chip --------------------------
-
+    # ---- Plugins available for this chip ------------------------------------
     set(_NAND_C ${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/src/nand.c)
-
-    if(NOT EXISTS "${_NAND_C}")
+    if(EXISTS "${_NAND_C}")
+        stub_add_plugin(
+            NAME          nand
+            SOURCES
+                nand_plugin.c
+                ${_NAND_C}
+                ${ESP_STUB_LIB_DIR}/src/md5.c
+                ${ESP_STUB_LIB_DIR}/src/target/common/src/md5.c
+                ${ESP_STUB_LIB_DIR}/src/rom_wrappers.c
+            LINKER_SCRIPT ${LINKER_SCRIPTS_DIR}/nand_plugin.ld
+        )
+    else()
         message(STATUS "No NAND support for ${TARGET_CHIP}, skipping NAND plugin build.")
     endif()
-
-    # ---- Compute plugin addresses (requires base ELF to exist) --------------
-
-    if(EXISTS "${BASE_ELF}")
-        execute_process(
-            COMMAND ${CMAKE_SOURCE_DIR}/tools/compute_plugin_addrs.py
-                    ${BASE_ELF}
-                    ${PLUGIN_ADDRS_FILE}
-            RESULT_VARIABLE _ret
-        )
-        if(NOT _ret EQUAL 0)
-            message(WARNING "compute_plugin_addrs.py failed; plugin(s) not built this run")
-        endif()
-    endif()
-
-    include(${PLUGIN_ADDRS_FILE} OPTIONAL RESULT_VARIABLE _have_plugin_addrs)
-
-    if(_have_plugin_addrs)
-        # ---- Pass 2: build each plugin binary -------------------------------
-
-        if(EXISTS "${_NAND_C}")
-            stub_add_plugin(
-                NAME          nand
-                SOURCES
-                    nand_plugin.c
-                    ${_NAND_C}
-                    ${ESP_STUB_LIB_DIR}/src/md5.c
-                    ${ESP_STUB_LIB_DIR}/src/target/common/src/md5.c
-                    ${ESP_STUB_LIB_DIR}/src/rom_wrappers.c
-                LINKER_SCRIPT ${LINKER_SCRIPTS_DIR}/nand_plugin.ld
-                TEXT_ADDR     NAND_PLUGIN_TEXT_ADDR
-                BSS_ADDR      NAND_PLUGIN_BSS_ADDR
-            )
-        endif()
-
-        # ---- Post-build: regenerate JSON with all plugin data embedded ------
-        if(_PLUGIN_TARGETS)
-            # Rebuild JSON after the last plugin ELF is produced.
-            # We attach the command to the last plugin target so it runs once
-            # all plugins are linked.
-            # The base POST_BUILD already wrote .base.json; the combined step
-            # writes the final .json — so exactly one writer per output file.
-            list(GET _PLUGIN_TARGETS -1 _last_plugin_target)
-            add_custom_command(TARGET ${_last_plugin_target} POST_BUILD
-                COMMAND ${CMAKE_SOURCE_DIR}/tools/elf2json.py
-                        ${BASE_ELF}
-                        ${BASE_JSON}
-                        ${_PLUGIN_ELF2JSON_ARGS}
-                COMMENT "Generating combined stub+plugin(s) JSON"
-            )
-        else()
-            # Plugin-capable chip but no plugins apply (e.g. NAND C source absent).
-            # The base POST_BUILD wrote .base.json; promote it to .json so that
-            # the output filename is consistent regardless of whether plugins built.
-            add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy ${BASE_ONLY_JSON} ${BASE_JSON}
-                COMMENT "Promoting base.json → ${TARGET_CHIP}.json (no plugins)"
-            )
-        endif()
-    else()
-        # plugin_addrs.cmake not yet generated (first cmake+build pass).
-        # The base POST_BUILD already wrote .base.json; promote it so that
-        # esptool can use the stub even before plugins are configured.
-        add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy ${BASE_ONLY_JSON} ${BASE_JSON}
-            COMMENT "Promoting base.json → ${TARGET_CHIP}.json (first pass)"
-        )
-        message(STATUS
-            "plugin_addrs.cmake not found — build once to generate base stub ELF, "
-            "then re-run cmake to configure the plugin(s).")
-    endif()
 endif()
+
+# ---------------------------------------------------------------------------
+# Stub JSON — one writer for every chip.  With no plugins the arg/dep lists are
+# empty and this is just `elf2json.py <stub.elf> <chip>.json`; with plugins it
+# also embeds each plugin's .text/.bss and handler offsets.
+# ---------------------------------------------------------------------------
+add_custom_command(
+    OUTPUT  ${STUB_JSON}
+    COMMAND ${CMAKE_SOURCE_DIR}/tools/elf2json.py ${BASE_ELF} ${STUB_JSON} ${_plugin_json_args}
+    DEPENDS ${BASE_ELF} ${_plugin_elfs} ${CMAKE_SOURCE_DIR}/tools/elf2json.py
+    COMMENT "Generating ${TARGET_CHIP}.json"
+    VERBATIM
+)
+add_custom_target(${TARGET_NAME}-json ALL DEPENDS ${STUB_JSON})

--- a/src/ld/nand_plugin.ld
+++ b/src/ld/nand_plugin.ld
@@ -5,7 +5,8 @@
  *
  * Generic NAND plugin linker script.
  *
- * The following values must be supplied via -Wl,--defsym by CMake:
+ * The following values are supplied by a generated fragment
+ * (<name>_plugin_addrs.ld) that CMake pulls in via -T before this script:
  *   PLUGIN_TEXT_ADDR          — IRAM load address (base text_end, 16-byte aligned)
  *   PLUGIN_BSS_ADDR           — DRAM load address (base data_end, 4-byte aligned)
  */

--- a/tools/build_all_chips.sh
+++ b/tools/build_all_chips.sh
@@ -31,15 +31,8 @@ for chip in "${ALL_CHIPS[@]}"; do
     echo "========================================="
     DIR=build-$chip
 
-    # Pass 1: build base stub ELF
-    mkdir -p "$DIR"
+    # Single pass: CMake wires the base stub, plugin address computation, plugin
+    # ELF(s), and JSON as one dependency graph, so a plain ninja builds it all.
     cmake -G Ninja -B "$DIR" -DTARGET_CHIP=$chip --fresh -Wno-dev
-    ninja -C "$DIR" "stub-$chip"
-
-    # Pass 2: re-configure (CMake runs compute_plugin_addrs.py to generate plugin_addrs.cmake
-    # now that the base ELF exists), then build the plugin and regenerate the JSON
-    if [ "$chip" != "esp8266" ] && [ "$chip" != "esp32" ]; then
-        cmake -B "$DIR" -DTARGET_CHIP=$chip -Wno-dev
-        ninja -C "$DIR"
-    fi
+    ninja -C "$DIR"
 done

--- a/tools/compute_plugin_addrs.py
+++ b/tools/compute_plugin_addrs.py
@@ -2,12 +2,21 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 """
-Compute plugin load addresses and base stub symbol addresses from a built
-base stub ELF.  Writes a CMake-includable file with the results.
+Compute a plugin's load addresses from the base stub ELF and emit a linker
+script fragment defining PLUGIN_TEXT_ADDR and PLUGIN_BSS_ADDR.
 
-Supports multiple plugins via repeated --plugin NAME ELF arguments.  Each
-plugin is stacked after the previous one; the first plugin starts immediately
-after the base stub.
+A plugin is loaded immediately after the base stub.  Multiple plugins stack:
+pass each preceding plugin's ELF via --after, in load order, so this plugin is
+placed after them.
+
+    # First plugin: right after the base stub
+    compute_plugin_addrs.py base.elf nand_plugin_addrs.ld
+
+    # Second plugin: stacked after the first
+    compute_plugin_addrs.py base.elf spi_ram_plugin_addrs.ld --after nand_plugin.elf
+
+The generated fragment is pulled in by the plugin's linker script via -T and
+supplies the MEMORY origins, replacing the old configure-time -Wl,--defsym.
 """
 
 import argparse
@@ -23,131 +32,65 @@ def align_up(value, alignment):
     return (value + alignment - 1) & ~(alignment - 1)
 
 
+def _section_end(elf, name, path):
+    sec = elf.get_section_by_name(name)
+    if sec is None:
+        sys.exit(f'ERROR: {name} section not found in base stub ELF {path}')
+    return sec['sh_addr'] + sec['sh_size']
+
+
+def _section_size(elf, name):
+    sec = elf.get_section_by_name(name)
+    return sec['sh_size'] if sec is not None else 0
+
+
 def main():
-    parser = argparse.ArgumentParser(description='Compute plugin load addresses from a base stub ELF.')
-    parser.add_argument(
-        'base_stub_elf',
-        help='Path to the base stub ELF file',
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument('base_stub_elf', help='Path to the base stub ELF file')
+    parser.add_argument('output_ld', help='Path to the linker fragment to write')
     parser.add_argument(
-        'output_cmake',
-        help='Path to the output CMake file',
-    )
-    parser.add_argument(
-        '--plugin',
-        nargs=2,
-        metavar=('NAME', 'PLUGIN_ELF'),
+        '--after',
         action='append',
         default=[],
-        help='Plugin to allocate addresses for: --plugin <name> <plugin_elf>. '
-        'May be repeated; plugins are stacked in order.',
-    )
-    parser.add_argument(
-        '--reserve',
-        nargs=3,
-        metavar=('NAME', 'TEXT_SIZE', 'BSS_SIZE'),
-        action='append',
-        default=[],
-        help='Fallback reservation sizes (hex or decimal) for a plugin whose ELF is not yet built: '
-        '--reserve <name> <text_size> <bss_size>. May be repeated.',
+        metavar='PLUGIN_ELF',
+        help='ELF of a plugin loaded before this one; repeat in load order to stack.',
     )
     args = parser.parse_args()
 
-    # Parse --reserve entries into a dict keyed by lower-case plugin name
-    reserves = {}
-    for res_name, res_text, res_bss in args.reserve:
-        try:
-            reserves[res_name.lower()] = (int(res_text, 0), int(res_bss, 0))
-        except ValueError:
-            sys.exit(f'ERROR: --reserve {res_name}: TEXT_SIZE and BSS_SIZE must be integers (hex or decimal)')
-
     with open(args.base_stub_elf, 'rb') as f:
         elf = ELFFile(f)
+        text_end = _section_end(elf, '.text', args.base_stub_elf)
+        data_end = _section_end(elf, '.data', args.base_stub_elf)
+        bss_end = _section_end(elf, '.bss', args.base_stub_elf)
 
-        text_sec = elf.get_section_by_name('.text')
-        data_sec = elf.get_section_by_name('.data')
-        bss_sec = elf.get_section_by_name('.bss')
+    # First plugin slot starts immediately after the base stub.  Place plugin
+    # BSS after both .data and .bss to avoid overlap.
+    text_addr = align_up(text_end, 16)
+    bss_addr = align_up(max(data_end, bss_end), 4)
 
-        if text_sec is None:
-            sys.exit('ERROR: .text section not found in base stub ELF')
-        if data_sec is None:
-            sys.exit('ERROR: .data section not found in base stub ELF')
-        if bss_sec is None:
-            sys.exit('ERROR: .bss section not found in base stub ELF')
+    # Stack past each preceding plugin, in load order.
+    for plugin_elf in args.after:
+        try:
+            with open(plugin_elf, 'rb') as pf:
+                p_elf = ELFFile(pf)
+                p_text_size = _section_size(p_elf, '.text')
+                p_bss_size = _section_size(p_elf, '.bss')
+        except FileNotFoundError:
+            sys.exit(f"ERROR: preceding plugin ELF not found: '{plugin_elf}'")
+        text_addr = align_up(text_addr + p_text_size, 16)
+        bss_addr = align_up(bss_addr + p_bss_size, 4)
 
-        text_end = text_sec['sh_addr'] + text_sec['sh_size']
-        data_end = data_sec['sh_addr'] + data_sec['sh_size']
-        bss_end = bss_sec['sh_addr'] + bss_sec['sh_size']
+    with open(args.output_ld, 'w') as out:
+        out.write('/* Auto-generated by compute_plugin_addrs.py — do not edit */\n')
+        out.write(f'PLUGIN_TEXT_ADDR = 0x{text_addr:08X};\n')
+        out.write(f'PLUGIN_BSS_ADDR  = 0x{bss_addr:08X};\n')
 
-        # First plugin starts immediately after the base stub
-        next_text_addr = align_up(text_end, 16)
-        # Place plugin BSS after both .data and .bss to avoid overlap
-        next_bss_addr = align_up(max(data_end, bss_end), 4)
-
-    lines = []
-
-    # Allocate addresses sequentially for each requested plugin.
-    # If no --plugin arguments are given (legacy/first-pass invocation), fall
-    # back to computing NAND addresses under the old variable names so that
-    # existing CMakeLists.txt that includes this file without --plugin still works.
-    if not args.plugin:
-        lines.insert(0, f'set(NAND_PLUGIN_BSS_ADDR  0x{next_bss_addr:08X})')
-        lines.insert(0, f'set(NAND_PLUGIN_TEXT_ADDR 0x{next_text_addr:08X})')
-    else:
-        for plugin_name, plugin_elf in args.plugin:
-            name_upper = plugin_name.upper()
-            lines.append(f'set({name_upper}_PLUGIN_TEXT_ADDR 0x{next_text_addr:08X})')
-            lines.append(f'set({name_upper}_PLUGIN_BSS_ADDR  0x{next_bss_addr:08X})')
-
-            # Advance pointers past this plugin's sections
-            try:
-                with open(plugin_elf, 'rb') as pf:
-                    p_elf = ELFFile(pf)
-                    p_text_sec = p_elf.get_section_by_name('.text')
-                    p_bss_sec = p_elf.get_section_by_name('.bss')
-                    p_text_size = p_text_sec['sh_size'] if p_text_sec else 0
-                    p_bss_size = p_bss_sec['sh_size'] if p_bss_sec else 0
-            except FileNotFoundError:
-                # Plugin ELF not built yet.  Check for an explicit --reserve entry.
-                reserve = reserves.get(plugin_name.lower())
-                if reserve is not None:
-                    p_text_size, p_bss_size = reserve
-                    print(
-                        f"WARNING: plugin ELF '{plugin_elf}' not found; "
-                        f'using reserved sizes TEXT=0x{p_text_size:X} BSS=0x{p_bss_size:X} for {plugin_name!r}.',
-                        file=sys.stderr,
-                    )
-                else:
-                    # No reserve provided.  If there are subsequent plugins their
-                    # addresses would overlap — fail fast with an actionable message.
-                    remaining = args.plugin[args.plugin.index([plugin_name, plugin_elf]) + 1 :]
-                    if remaining:
-                        sys.exit(
-                            f"ERROR: plugin ELF '{plugin_elf}' not found and no --reserve entry for {plugin_name!r}. "
-                            f'Subsequent plugins {[n for n, _ in remaining]} would receive overlapping addresses. '
-                            f'Build {plugin_name!r} first, or pass --reserve {plugin_name} <text_size> <bss_size>.'
-                        )
-                    # Single (last) plugin missing — harmless, emit warning only.
-                    print(
-                        f"WARNING: plugin ELF '{plugin_elf}' not found; "
-                        f'subsequent plugin addresses may be incorrect (first-pass build?)',
-                        file=sys.stderr,
-                    )
-                    p_text_size = 0
-                    p_bss_size = 0
-
-            # Align text to 16 bytes (same rule as base→first-plugin gap)
-            next_text_addr = align_up(next_text_addr + p_text_size, 16)
-            next_bss_addr = align_up(next_bss_addr + p_bss_size, 4)
-
-    with open(args.output_cmake, 'w') as out:
-        out.write('# Auto-generated by compute_plugin_addrs.py — do not edit\n')
-        for line in lines:
-            out.write(line + '\n')
-
-    print(f'Plugin addresses written to {args.output_cmake}')
-    for line in lines:
-        print(f'  {line}')
+    print(f'Plugin load addresses written to {args.output_ld}')
+    print(f'  PLUGIN_TEXT_ADDR = 0x{text_addr:08X}')
+    print(f'  PLUGIN_BSS_ADDR  = 0x{bss_addr:08X}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Reworks the plugin build so plugin load addresses are computed at **build time** with ordinary CMake dependencies, rather than at configure time. A plugin build no longer needs two `cmake`+`ninja` cycles.

## Why

Plugin load addresses depend on the base stub's section sizes, which are known only after the base stub links. The old build computed them at configure time via an `execute_process()` that read the base stub ELF, and defined the plugin target only once a generated `plugin_addrs.cmake` existed. On a fresh tree the base ELF doesn't exist yet, so building required: `cmake` (no plugin) → `ninja` (base) → `cmake` (define plugin) → `ninja`. It also produced a `.base.json` intermediate plus three "promote `.base.json` → `chip.json`" copies, which existed only to keep a single writer per output file under `POST_BUILD`.

## How

- `compute_plugin_addrs.py` emits a linker fragment (`PLUGIN_TEXT_ADDR`/`PLUGIN_BSS_ADDR`) instead of a CMake file; the plugin linker script pulls it in via `-T`, replacing the configure-time `-Wl,--defsym`. A `LINK_DEPENDS` on the fragment relinks the plugin when the base stub changes. Plugins still stack via `--after`.
- A custom command produces each plugin's address fragment from the base stub ELF, so the plugin depends on the base stub and editing a base source cascades: base → addresses → plugin → JSON.
- JSON generation becomes a single `add_custom_command(OUTPUT)` + custom target for every chip, dropping the `.base.json` intermediate and the promote copies.
- `build_all_chips.sh` no longer needs a second pass; docs updated.

Rebased on current `master` (post-#74 LTO): the plugin still links with the global `--gc-sections` and relies on the `EXTERN()`/`PLUGIN_HANDLER` handler retention introduced there — the generated fragment only supplies load addresses.

## Verification

The produced stub JSON is **byte-identical** (matching SHA-256) to the previous two-pass build, across all three of the old JSON-writing code paths:

| Chip | Old path exercised | Result |
|---|---|---|
| esp32s3 | base + plugin + combined JSON | identical |
| esp32 | non-plugin, wrote `chip.json` directly | identical |
| esp32p4 | plugin-capable, no plugin (`.base.json` + promote copy) | identical |

Also verified on `esp32s3`/`esp32p4`/`esp32`:

- a single `cmake && ninja` builds base → addresses → plugin → JSON in order;
- re-running `ninja` is a no-op (no spurious rebuilds);
- editing a base source relinks the plugin and regenerates the JSON; editing only the plugin rebuilds just the plugin + JSON;
- the plugin retains all 10 NAND handlers under LTO + `--gc-sections`.

The only artifact removed is the private `*.base.json` intermediate, which the release workflow, `install_all_chips.sh`, and `compare_sizes.py` already excluded — so nothing downstream changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
