### PR TITLE
fix(flash): remove faulty guard in flash_defl_data handler

### DIFF
--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -398,8 +398,6 @@ static int s_flash_defl_begin(const struct cmd_ctx *ctx)
 
 static int s_flash_defl_data(const struct cmd_ctx *ctx)
 {
-#define ADLER32_CHECKSUM_SIZE 4
-
     if (ctx->packet_size < FLASH_DEFL_DATA_HEADER_SIZE) {
         return RESPONSE_BAD_DATA_LEN;
     }
@@ -407,12 +405,6 @@ static int s_flash_defl_data(const struct cmd_ctx *ctx)
     int check = s_check_flash_in_progress();
     if (check != RESPONSE_SUCCESS) {
         return check;
-    }
-
-    // If all expected data has already been decompressed and written,
-    // only accept the checksum if it is part of the data.
-    if (s_flash_state.total_remaining == 0 && ctx->packet_size > ADLER32_CHECKSUM_SIZE) {
-        return RESPONSE_TOO_MUCH_DATA;
     }
 
     uint32_t data_size = get_le_to_u32(ctx->data);
@@ -429,7 +421,6 @@ static int s_flash_defl_data(const struct cmd_ctx *ctx)
     s_pending_post_process = s_flash_defl_data_post_process;
 
     return RESPONSE_SUCCESS;
-#undef ADLER32_CHECKSUM_SIZE
 }
 
 static int s_flash_defl_end(const struct cmd_ctx *ctx)


### PR DESCRIPTION
## Problem

When flashing with compression, the stub returns `RESPONSE_TOO_MUCH_DATA (0xC900)` if the compressed payload size is exactly **N × block_size + 1** bytes (e.g. 65537 bytes with a 16384-byte block size).

### Root cause

`s_flash_defl_data` contained this guard:

```c
if (s_flash_state.total_remaining == 0 && ctx->packet_size > ADLER32_CHECKSUM_SIZE) {
    return RESPONSE_TOO_MUCH_DATA;
}
```

`total_remaining` tracks **uncompressed** bytes left to write. It reaches zero as soon as all decompressed output has been flushed to flash — which can happen while the last few bytes of the **compressed** zlib stream (specifically the trailing Adler32 checksum bytes) are still in flight.

With a 65537-byte compressed payload and 16384-byte blocks:
- Packets seq 0–3 cover bytes `[0, 65536)`. By the end of seq 3, tinfl has written all decompressed data → `total_remaining = 0`. tinfl returns `TINFL_STATUS_NEEDS_MORE_INPUT` because byte 65536 (last Adler32 byte) hasn't arrived yet.
- Packet seq 4 carries that final 1 byte. The guard sees `total_remaining == 0` and `packet_size > 4` → **false positive `RESPONSE_TOO_MUCH_DATA`**.

The `ADLER32_CHECKSUM_SIZE` (4) comparison was also effectively dead code — `ctx->packet_size` always includes at least `FLASH_DEFL_DATA_HEADER_SIZE` (≥ 8 bytes), so it is always `> 4`.

## Fix

Remove the guard entirely. `tinfl` already returns `TINFL_STATUS_FAILED` if fed data after the stream is complete, which the existing `status < TINFL_STATUS_DONE` check in `s_flash_defl_data_post_process` correctly converts to `RESPONSE_INFLATE_ERROR`. The guard was redundant.

## Reproduction

```python
# Generate a binary whose zlib-compressed size is exactly 65537 bytes
import zlib, random

def make_data(size):
    r = random.Random(7)
    return bytes(0 if r.random() < 0.6 else r.getrandbits(8) for _ in range(size))

data = make_data(107686)
assert len(zlib.compress(data + b'\xff' * 2, 9)) == 65537
open('test.bin', 'wb').write(data)

# Flash with compression — fails on unpatched stub, succeeds after this fix
# esptool --chip esp32c6 --port /dev/ttyUSB0 write-flash --compress 0x0 test.bin
```

Before fix:
```
Compressed 107688 bytes to 65537...
A fatal error occurred: Failed to write compressed data to flash after seq 4 (result was C900: Too much data)
```

After fix:
```
Compressed 107688 bytes to 65537...
Wrote 107688 bytes (65537 compressed) at 0x00000000 in 6.3 seconds (135.7 kbit/s).
Hash of data verified.
```