### PR TITLE
feat(esp32s3): Add SDMMC card support via plugin (ESPTOOL-1331)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project aims to replace the legacy [flasher stub of esptool](https://github
 - [Development Guide](docs/development-guide.md) - Contributing guidelines, testing, CI/CD, and release process
 - [Plugin System](docs/plugin-system.md) - Runtime-loadable plugin architecture and guide for adding new plugins
 - [NAND Flash Support](docs/plugins/nand-flash.md) - NAND flash programming support (preview)
+- [SDMMC Card Support](docs/plugins/sdmmc.md) - SD/MMC card programming support (preview)
 
 ## Supported Chips
 

--- a/docs/plugins/sdmmc.md
+++ b/docs/plugins/sdmmc.md
@@ -1,0 +1,107 @@
+# SDMMC Card Support
+
+> [!WARNING]
+> SDMMC support is in **preview** state. It has been tested with SDHC/SDSC SD cards on ESP32-S3. The API and behavior may change in future releases.
+
+## Supported Hardware
+
+### Cards
+
+SD (SDSC/SDHC/SDXC) and eMMC chips accessed over the SDMMC bus in 1-bit or 4-bit mode. 8-bit eMMC init is not yet implemented.
+
+### Supported MCUs
+
+**ESP32-S3 only** (for now). Other chips with an SDMMC peripheral (ESP32, ESP32-P4) are not yet supported.
+
+## Geometry
+
+Fixed at 512-byte sectors (the SD/MMC standard). All host-facing offsets and sizes must be sector-aligned.
+
+## Clock Source
+
+The stub uses **XTAL (40 MHz)** as the SDMMC clock source rather than PLL_F160M.
+
+The IDF bootloader enables PLL_F160M during startup, but the ROM bootloader (which runs before the stub) does not — selecting `clk_sel=1` in stub mode leaves the controller's internal state machines unclocked and every command times out. XTAL caps card clock at 20 MHz (SD Default Speed), which is sufficient for the flasher stub's use case.
+
+## Protocol Overview
+
+SDMMC support is implemented as a [plugin](../plugin-system.md) that runs on top of the base stub. The base stub JSON for ESP32-S3 includes a `plugins.sdmmc` section with the plugin binary, load addresses, and a handler offset table. The host tool detects the plugin via the `plugins` key in the stub JSON and loads it when SDMMC operations are requested.
+
+All SDMMC opcodes (`0xDF`–`0xE5`) are dispatched through the FPT. The handler signature is `plugin_cmd_handler_t` (see `plugin_table.h`).
+
+## Opcode Reference
+
+### `0xDF` — `SDMMC_ATTACH`
+
+**Request payload**: 16-byte `stub_target_sdmmc_attach_config_t`:
+
+| Offset | Field | Notes |
+|---|---|---|
+| 0 | `slot` (u8) | 0 or 1; `0xFF` selects chip defaults |
+| 1 | `width` (u8) | 1, 4, or 8 |
+| 2 | `freq_khz` (u16 LE) | post-init bus frequency; 0 = 20 MHz default |
+| 4 | `cd_pin` (u8) | card-detect GPIO; `0xFF` = none |
+| 5 | `wp_pin` (u8) | write-protect GPIO; `0xFF` = none |
+| 6 | `pin_clk` (u8) | |
+| 7 | `pin_cmd` (u8) | |
+| 8 | `pin_d[8]` (u8×8) | D0..D7; entries past `width-1` ignored |
+
+Defaults (when `slot == 0xFF`) match ESP-IDF v6.0 `SDMMC_SLOT_CONFIG_DEFAULT` for ESP32-S3: CLK=14, CMD=15, D0=2, D1=4, D2=12, D3=13, D4=33, D5=34, D6=35, D7=36, slot 0, 4-bit, 20 MHz.
+
+**Response**: `value` = capacity in sectors. Extra payload (12 bytes): OCR (LE), RCA (LE), flags (bit0=is_mmc, bit1=is_high_capacity, bits[7:4]=actual width). On failure `value` carries a packed `{stage, err, RINTSTS}` diagnostic word — see `target/sdmmc.h`.
+
+---
+
+### `0xE0` — `SDMMC_READ_FLASH`
+
+**Request payload**: 4 × LE32: `offset`, `read_size`, `packet_size`, `max_inflight` (last informational; stub enforces a window of 1).
+
+**Response**: initial `RESPONSE_SUCCESS` frame, then streamed data packets followed by a 16-byte MD5 digest. On mid-stream read failure the stub continues with zero-filled packets and corrupts the MD5 to surface as host-side verification failure.
+
+---
+
+### `0xE1` — `SDMMC_WRITE_FLASH_BEGIN`
+
+**Request payload**: 4 × LE32: `offset` (sector-aligned), `total_size`, `block_size`, `packet_size` (last two informational).
+
+**Response**: `RESPONSE_SUCCESS` or `RESPONSE_BAD_DATA_LEN`.
+
+---
+
+### `0xE2` — `SDMMC_WRITE_FLASH_DATA`
+
+**Request payload**: 16-byte header (`data_len` at offset 0) + `data_len` bytes of data. The XOR checksum must be in the command frame header at offset −4 relative to the payload pointer (same scheme as base `ESP_FLASH_DATA`).
+
+**Response**: `RESPONSE_SUCCESS` after each packet, or `RESPONSE_FAILED_SPI_OP` / `RESPONSE_NAND_PROGRAM_FAILED` on data-phase failure.
+
+---
+
+### `0xE3` — `SDMMC_WRITE_FLASH_END`
+
+**Request payload**: 4-byte LE `reboot_flag` (ignored — no chip-side reboot action).
+
+**Response**: `RESPONSE_SUCCESS` or `RESPONSE_BAD_DATA_LEN`. Pads any partial trailing sector with `0xFF` before flushing.
+
+---
+
+### `0xE4` — `SDMMC_ERASE_REGION`
+
+**Request payload**: 2 × LE32: `offset`, `erase_size`. Both must be sector-aligned.
+
+**Response**: `RESPONSE_SUCCESS`, `RESPONSE_BAD_DATA_LEN`, or `RESPONSE_FAILED_SPI_OP`. Implemented via CMD32/33/38 (SD) or CMD35/36/38 (eMMC).
+
+---
+
+### `0xE5` — `SDMMC_GET_INFO`
+
+**Request payload**: empty.
+
+**Response**: same fields as `SDMMC_ATTACH` plus 16 bytes of raw CID. Useful for host-side card identification once the card is attached.
+
+## Limitations
+
+- **Single-block transfers only** — CMD17/CMD24, one sector per command. Multi-block (CMD18/CMD25) would be faster but is not yet implemented.
+- **No bus-frequency override above 20 MHz** — High Speed (50 MHz) and UHS-I are not implemented. Would require explicitly enabling PLL_F160M (regi2c sequence).
+- **No SDSC capacity reporting** — only CSD v2.0 (SDHC/SDXC, eMMC ≥ 2 GB) capacity is decoded. SDSC cards still read/write correctly but `capacity_bytes` is reported as 0.
+- **No 8-bit eMMC init** — CMD6 SWITCH for eMMC bus-width change is not implemented.
+- **Polled I/O** — no interrupt handling. Single 512-byte IDMAC descriptor per transfer.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,10 +113,32 @@ if(NOT TARGET_CHIP STREQUAL "esp8266" AND NOT TARGET_CHIP STREQUAL "esp32")
 
     # ---- Discover which plugins apply to this chip --------------------------
 
-    set(_NAND_C ${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/src/nand.c)
+    set(_NAND_C  ${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/src/nand.c)
+    set(_SDMMC_C ${ESP_STUB_LIB_DIR}/src/target/${ESP_TARGET}/src/sdmmc.c)
 
     if(NOT EXISTS "${_NAND_C}")
         message(STATUS "No NAND support for ${TARGET_CHIP}, skipping NAND plugin build.")
+    endif()
+    if(NOT EXISTS "${_SDMMC_C}")
+        message(STATUS "No SDMMC support for ${TARGET_CHIP}, skipping SDMMC plugin build.")
+    endif()
+
+    # ---- Build --plugin/--reserve args for compute_plugin_addrs.py ----------
+    # Reserve sizes are upper bounds used on the first build pass (before any
+    # plugin ELF exists).  Once a plugin's ELF is present compute_plugin_addrs.py
+    # reads its actual size instead of using the reserve.  Keep the reserve a
+    # comfortable multiple of the current footprint to avoid address churn
+    # between builds when one plugin grows.
+    set(_addr_args "")
+    if(EXISTS "${_NAND_C}")
+        list(APPEND _addr_args
+            --plugin nand ${CMAKE_BINARY_DIR}/src/stub-${TARGET_CHIP}-nand-plugin${CMAKE_EXECUTABLE_SUFFIX_C}
+            --reserve nand 0x4000 0x2000)
+    endif()
+    if(EXISTS "${_SDMMC_C}")
+        list(APPEND _addr_args
+            --plugin sdmmc ${CMAKE_BINARY_DIR}/src/stub-${TARGET_CHIP}-sdmmc-plugin${CMAKE_EXECUTABLE_SUFFIX_C}
+            --reserve sdmmc 0x4000 0x2000)
     endif()
 
     # ---- Compute plugin addresses (requires base ELF to exist) --------------
@@ -126,6 +148,7 @@ if(NOT TARGET_CHIP STREQUAL "esp8266" AND NOT TARGET_CHIP STREQUAL "esp32")
             COMMAND ${CMAKE_SOURCE_DIR}/tools/compute_plugin_addrs.py
                     ${BASE_ELF}
                     ${PLUGIN_ADDRS_FILE}
+                    ${_addr_args}
             RESULT_VARIABLE _ret
         )
         if(NOT _ret EQUAL 0)
@@ -150,6 +173,21 @@ if(NOT TARGET_CHIP STREQUAL "esp8266" AND NOT TARGET_CHIP STREQUAL "esp32")
                 LINKER_SCRIPT ${LINKER_SCRIPTS_DIR}/nand_plugin.ld
                 TEXT_ADDR     NAND_PLUGIN_TEXT_ADDR
                 BSS_ADDR      NAND_PLUGIN_BSS_ADDR
+            )
+        endif()
+
+        if(EXISTS "${_SDMMC_C}")
+            stub_add_plugin(
+                NAME          sdmmc
+                SOURCES
+                    sdmmc_plugin.c
+                    ${_SDMMC_C}
+                    ${ESP_STUB_LIB_DIR}/src/md5.c
+                    ${ESP_STUB_LIB_DIR}/src/target/common/src/md5.c
+                    ${ESP_STUB_LIB_DIR}/src/rom_wrappers.c
+                LINKER_SCRIPT ${LINKER_SCRIPTS_DIR}/sdmmc_plugin.ld
+                TEXT_ADDR     SDMMC_PLUGIN_TEXT_ADDR
+                BSS_ADDR      SDMMC_PLUGIN_BSS_ADDR
             )
         endif()
 

--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -987,7 +987,9 @@ void handle_command(const uint8_t *buffer, size_t size, const struct stub_transp
     if (accumulated_result == RESPONSE_SUCCESS) {
         s_send_response(transport, command, RESPONSE_SUCCESS, &response);
     } else {
-        s_send_response(transport, command, accumulated_result, NULL);
+        // Pass &response so handlers can surface diagnostic detail in
+        // response.value on the error path (e.g. plugin-specific error codes).
+        s_send_response(transport, command, accumulated_result, &response);
         s_pending_post_process = NULL;
     }
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -49,6 +49,14 @@ extern "C" {
 #define ESP_SPI_NAND_ERASE_REGION     0xDC
 #define ESP_SPI_NAND_READ_PAGE_DEBUG 0xDD
 #define ESP_SPI_NAND_WRITE_FLASH_END 0xDE
+// SDMMC card commands (stub only)
+#define ESP_SDMMC_ATTACH             0xDF
+#define ESP_SDMMC_READ_FLASH         0xE0
+#define ESP_SDMMC_WRITE_FLASH_BEGIN  0xE1
+#define ESP_SDMMC_WRITE_FLASH_DATA   0xE2
+#define ESP_SDMMC_WRITE_FLASH_END    0xE3
+#define ESP_SDMMC_ERASE_REGION       0xE4
+#define ESP_SDMMC_GET_INFO           0xE5
 
 /**
  * @brief ESP command response codes (16-bit)
@@ -112,6 +120,21 @@ enum esp_response_code {
 #define SPI_NAND_READ_PAGE_DEBUG_SIZE 4
 /* reboot_flag (uint32_t LE) — mirrors FLASH_END_SIZE */
 #define SPI_NAND_WRITE_FLASH_END_SIZE 4
+// SDMMC command sizes
+/* 16-byte stub_target_sdmmc_attach_config_t (slot, width, freq_khz, cd, wp,
+ * clk, cmd, d0..d7). Slot=0xFF triggers IDF-default pin mapping. */
+#define SDMMC_ATTACH_SIZE             16
+/* offset, size, packet_size, max_inflight — same layout as ESP_READ_FLASH */
+#define SDMMC_READ_FLASH_SIZE         16
+/* offset, total_size, block_size, packet_size — same layout as ESP_FLASH_BEGIN */
+#define SDMMC_WRITE_FLASH_BEGIN_SIZE  16
+/* mirrors FLASH_DATA_HEADER_SIZE */
+#define SDMMC_WRITE_FLASH_DATA_HEADER_SIZE 16
+/* reboot_flag */
+#define SDMMC_WRITE_FLASH_END_SIZE    4
+/* start_offset, length (both byte units) */
+#define SDMMC_ERASE_REGION_SIZE       8
+#define SDMMC_GET_INFO_SIZE           0
 
 #ifdef __cplusplus
 }

--- a/src/ld/sdmmc_plugin.ld
+++ b/src/ld/sdmmc_plugin.ld
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SDMMC plugin linker script.  PLUGIN_TEXT_ADDR / PLUGIN_BSS_ADDR are supplied
+ * via -Wl,--defsym by CMake based on the base stub's text/data end addresses.
+ * See docs/plugin-system.md.
+ */
+
+MEMORY {
+    iram : org = PLUGIN_TEXT_ADDR, len = 0x8000
+    dram : org = PLUGIN_BSS_ADDR,  len = 0x4000
+}
+
+INCLUDE common.ld
+
+/* Override ENTRY(esp_main) from common.ld; ENTRY alone roots only this symbol,
+ * so EXTERN every other handler from PLUGIN_HANDLER_SYMBOLS['sdmmc']. */
+ENTRY(sdmmc_plugin_attach)
+EXTERN(sdmmc_plugin_attach);
+EXTERN(sdmmc_plugin_read_flash);
+EXTERN(sdmmc_plugin_write_flash_begin);
+EXTERN(sdmmc_plugin_write_flash_data);
+EXTERN(sdmmc_plugin_write_flash_end);
+EXTERN(sdmmc_plugin_erase_region);
+EXTERN(sdmmc_plugin_get_info);
+
+ASSERT(SIZEOF(.data) == 0, "Plugin must not have initialized .data — use BSS instead")

--- a/src/sdmmc_plugin.c
+++ b/src/sdmmc_plugin.c
@@ -1,0 +1,408 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SDMMC card plugin — compiled as a separate binary loaded at runtime by
+ * esptool.  Bridges the stub's plugin opcodes (0xDF..0xE5) to the per-target
+ * SDMMC HAL.  Streaming callbacks use ctx->transport so the plugin is
+ * independent of the host transport (UART/USB/SDIO).
+ */
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/md5.h>
+#include <target/sdmmc.h>
+#include "commands.h"
+#include "command_handler.h"
+#include "endian_utils.h"
+#include "plugin_table.h"
+#include "transport.h"
+
+#define SECTOR_SIZE      SDMMC_SECTOR_SIZE
+#define MD5_DIGEST_SIZE  16U
+// Upper bound for per-packet host transfer; bounds send_buf in the streaming
+// read post-process.  4 KB matches esptool's FLASH_SECTOR_SIZE.
+#define MAX_PACKET_SIZE  (SECTOR_SIZE * 8U)
+#define CHECKSUM_INIT    0xEFU
+// Host flow control: one in-flight packet at a time.  Raising this would
+// increase throughput at the cost of a larger host reassembly buffer.
+#define MAX_UNACKED_PACKETS  1U
+
+// ---- Plugin BSS state --------------------------------------------------- //
+
+// Scratch sector used by read fill / write flush.
+static uint8_t s_sector_buf[SECTOR_SIZE] __attribute__((aligned(4)));
+
+// Write session — page_buf accumulates partial sectors until full.
+static struct {
+    uint32_t offset;
+    uint32_t total_remaining;
+    uint8_t  sector_buf[SECTOR_SIZE] __attribute__((aligned(4)));
+    uint32_t sector_buf_filled;
+    bool     in_progress;
+} s_write_state;
+
+// Read session — params stashed by sdmmc_plugin_read_flash for the post-process.
+static struct {
+    uint32_t offset;
+    uint32_t read_size;
+    uint32_t packet_size;
+} s_read_state;
+
+// ---- Helpers ------------------------------------------------------------ //
+
+static int sdmmc_err_to_response(int err)
+{
+    if (err == 0) {
+        return RESPONSE_SUCCESS;
+    }
+    // Reuse NAND program-failed for chip-side data errors; everything else
+    // surfaces as the generic SPI_OP code with the SDMMC_ERR_* code packed in
+    // resp->value (decoded by the host).
+    if (err == SDMMC_ERR_DATA_FAIL) {
+        return RESPONSE_NAND_PROGRAM_FAILED;
+    }
+    if (err == SDMMC_ERR_BAD_ARG) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+    return RESPONSE_FAILED_SPI_OP;
+}
+
+// Pack {stage, err, rintsts} so the host can decode which init step died and
+// what controller-interrupt bits looked like at that moment.  Layout:
+//   bits[31:24] = stage (SDMMC_DIAG_STAGE_* or SD CMD index)
+//   bits[23:16] = (int8_t)err — signed SDMMC_ERR_* code
+//   bits[15:0]  = lower 16 bits of RINTSTS
+static uint32_t pack_diag_value(int err)
+{
+    uint8_t  stage   = SDMMC_DIAG_STAGE_NONE;
+    uint32_t rintsts = 0;
+    stub_target_sdmmc_get_last_diag(&stage, &rintsts);
+    return ((uint32_t)stage << 24)
+           | ((uint32_t)((uint8_t)err) << 16)
+           | (rintsts & 0xFFFFU);
+}
+
+// Fill one host send packet by issuing single-sector reads covering
+// [current_offset, current_offset + size).
+static int fill_send_packet(uint8_t *dst, uint32_t *current_offset, uint32_t size)
+{
+    uint32_t filled = 0;
+    while (filled < size) {
+        uint32_t lba        = *current_offset / SECTOR_SIZE;
+        uint32_t sector_off = *current_offset % SECTOR_SIZE;
+        uint32_t avail      = SECTOR_SIZE - sector_off;
+        uint32_t need       = size - filled;
+        uint32_t chunk      = (avail < need) ? avail : need;
+
+        if (stub_target_sdmmc_read_sector(lba, s_sector_buf) != 0) {
+            return -1;
+        }
+        memcpy(dst + filled, s_sector_buf + sector_off, chunk);
+        filled          += chunk;
+        *current_offset += chunk;
+    }
+    return 0;
+}
+
+static int flush_write_sector(void)
+{
+    uint32_t lba = s_write_state.offset / SECTOR_SIZE;
+    int ret = stub_target_sdmmc_write_sector(lba, s_write_state.sector_buf);
+    if (ret != 0) {
+        return sdmmc_err_to_response(ret);
+    }
+    s_write_state.offset += SECTOR_SIZE;
+    s_write_state.sector_buf_filled = 0;
+    return RESPONSE_SUCCESS;
+}
+
+// ---- Streaming read post-process ---------------------------------------- //
+
+// On read failure we continue sending zero-filled packets so the host's
+// expected byte count is satisfied, then poison the final MD5 (XOR each byte
+// with 0xFF) so verification fails on the host side.  Same convention as
+// the NAND plugin.
+static int read_flash_post_process(const struct cmd_ctx *ctx)
+{
+    uint32_t offset      = s_read_state.offset;
+    uint32_t read_size   = s_read_state.read_size;
+    uint32_t packet_size = s_read_state.packet_size;
+
+    // In plugin BSS to avoid pushing it on the stack.
+    static uint8_t send_buf[MAX_PACKET_SIZE] __attribute__((aligned(4)));
+
+    ctx->transport->recv_release();
+
+    uint32_t remaining      = read_size;
+    uint32_t sent_packets   = 0;
+    uint32_t acked_bytes    = 0;
+    uint32_t acked_packets  = 0;
+    uint32_t current_offset = offset;
+    bool     read_failed    = false;
+
+    struct stub_lib_md5_ctx md5;
+    stub_lib_md5_init(&md5);
+
+    while (remaining > 0 || acked_bytes < read_size) {
+        size_t         slip_size;
+        bool           ack_err;
+        const uint8_t *slip_data = ctx->transport->recv_poll(&slip_size, &ack_err);
+        if (ack_err) {
+            ctx->transport->recv_release();
+        } else if (slip_data != NULL) {
+            if (slip_size == sizeof(acked_bytes)) {
+                memcpy(&acked_bytes, slip_data, sizeof(acked_bytes));
+                if (acked_packets < sent_packets) {
+                    acked_packets++;
+                }
+            }
+            ctx->transport->recv_release();
+        }
+
+        uint32_t unacked = (sent_packets >= acked_packets) ? (sent_packets - acked_packets) : 0;
+        if (remaining > 0 && unacked < MAX_UNACKED_PACKETS) {
+            uint32_t this_packet = (remaining < packet_size) ? remaining : packet_size;
+            if (!read_failed) {
+                if (fill_send_packet(send_buf, &current_offset, this_packet) != 0) {
+                    read_failed = true;
+                }
+            }
+            if (read_failed) {
+                memset(send_buf, 0, this_packet);
+            }
+
+            stub_lib_md5_update(&md5, send_buf, this_packet);
+            ctx->transport->send_frame(send_buf, this_packet);
+            remaining -= this_packet;
+            sent_packets++;
+        }
+    }
+
+    uint8_t digest[MD5_DIGEST_SIZE];
+    stub_lib_md5_final(&md5, digest);
+    if (read_failed) {
+        for (size_t i = 0; i < sizeof(digest); i++) {
+            digest[i] ^= 0xFF;
+        }
+    }
+    ctx->transport->send_frame(digest, sizeof(digest));
+    return RESPONSE_SUCCESS;
+}
+
+// ---- Handlers ----------------------------------------------------------- //
+
+int sdmmc_plugin_attach(uint8_t command, const uint8_t *data, uint32_t len, struct command_response_data *resp)
+{
+    (void)command;
+    if (len != SDMMC_ATTACH_SIZE) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    // Mirror the 16-byte on-wire payload into the config struct.
+    stub_target_sdmmc_attach_config_t cfg;
+    cfg.slot     = data[0];
+    cfg.width    = data[1];
+    cfg.freq_khz = get_le_to_u16(data + 2);
+    cfg.cd_pin   = data[4];
+    cfg.wp_pin   = data[5];
+    cfg.pin_clk  = data[6];
+    cfg.pin_cmd  = data[7];
+    for (uint32_t i = 0; i < 8; i++) {
+        cfg.pin_d[i] = data[8 + i];
+    }
+
+    int err = stub_target_sdmmc_attach(&cfg);
+    if (err != 0) {
+        resp->value = pack_diag_value(err);
+        return RESPONSE_FAILED_SPI_OP;
+    }
+
+    // Response: value = capacity in sectors; data carries OCR / RCA / flags.
+    const stub_target_sdmmc_card_info_t *ci = stub_target_sdmmc_get_card_info();
+    resp->value = (uint32_t)(ci->capacity_bytes / SECTOR_SIZE);
+    set_u32_to_le(resp->data + 0, ci->ocr);
+    set_u32_to_le(resp->data + 4, ci->rca);
+    uint32_t flags = (ci->is_mmc ? 1U : 0U) | (ci->is_high_capacity ? 2U : 0U) | ((uint32_t)ci->width << 4);
+    set_u32_to_le(resp->data + 8, flags);
+    resp->data_size = 12;
+    return RESPONSE_SUCCESS;
+}
+
+int sdmmc_plugin_read_flash(uint8_t command, const uint8_t *data, uint32_t len, struct command_response_data *resp)
+{
+    (void)command;
+    if (len != SDMMC_READ_FLASH_SIZE) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    uint32_t offset      = get_le_to_u32(data + 0);
+    uint32_t read_size   = get_le_to_u32(data + 4);
+    uint32_t packet_size = get_le_to_u32(data + 8);
+    // data + 12 = max_inflight (informational; the stub enforces window=1)
+    if (packet_size == 0 || packet_size > MAX_PACKET_SIZE) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    s_read_state.offset      = offset;
+    s_read_state.read_size   = read_size;
+    s_read_state.packet_size = packet_size;
+    resp->post_process       = read_flash_post_process;
+    return RESPONSE_SUCCESS;
+}
+
+int sdmmc_plugin_write_flash_begin(uint8_t command, const uint8_t *data, uint32_t len,
+                                   struct command_response_data *resp)
+{
+    (void)command;
+    (void)resp;
+    if (len != SDMMC_WRITE_FLASH_BEGIN_SIZE) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    uint32_t offset     = get_le_to_u32(data + 0);
+    uint32_t total_size = get_le_to_u32(data + 4);
+    // CMD24 (WRITE_BLOCK) cannot do partial-sector programs.
+    if ((offset % SECTOR_SIZE) != 0) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    s_write_state.offset            = offset;
+    s_write_state.total_remaining   = total_size;
+    s_write_state.sector_buf_filled = 0;
+    s_write_state.in_progress       = true;
+    return RESPONSE_SUCCESS;
+}
+
+int sdmmc_plugin_write_flash_data(uint8_t command, const uint8_t *data, uint32_t len,
+                                  struct command_response_data *resp)
+{
+    (void)command;
+    (void)resp;
+    if (len < SDMMC_WRITE_FLASH_DATA_HEADER_SIZE) {
+        return RESPONSE_NOT_ENOUGH_DATA;
+    }
+    if (!s_write_state.in_progress) {
+        return RESPONSE_NOT_IN_FLASH_MODE;
+    }
+
+    uint32_t       data_len    = get_le_to_u32(data);
+    const uint8_t *flash_data  = data + SDMMC_WRITE_FLASH_DATA_HEADER_SIZE;
+    uint32_t       actual_size = len - SDMMC_WRITE_FLASH_DATA_HEADER_SIZE;
+    if (data_len != actual_size) {
+        return RESPONSE_TOO_MUCH_DATA;
+    }
+    if (actual_size > s_write_state.total_remaining) {
+        return RESPONSE_TOO_MUCH_DATA;
+    }
+
+    // Same XOR checksum as base FLASH_DATA / NAND_WRITE_FLASH_DATA.  The
+    // checksum word sits in the SLIP header at offset -4 relative to data.
+    uint32_t chk = CHECKSUM_INIT;
+    for (uint32_t i = 0; i < actual_size; i++) {
+        chk ^= flash_data[i];
+    }
+    if (chk != get_le_to_u32(data - sizeof(uint32_t))) {
+        return RESPONSE_BAD_DATA_CHECKSUM;
+    }
+
+    uint32_t       to_process = actual_size;
+    const uint8_t *src        = flash_data;
+    while (to_process > 0) {
+        uint32_t space = SECTOR_SIZE - s_write_state.sector_buf_filled;
+        uint32_t chunk = (to_process < space) ? to_process : space;
+        memcpy(s_write_state.sector_buf + s_write_state.sector_buf_filled, src, chunk);
+        s_write_state.sector_buf_filled += chunk;
+        s_write_state.total_remaining   -= chunk;
+        src        += chunk;
+        to_process -= chunk;
+
+        if (s_write_state.sector_buf_filled >= SECTOR_SIZE) {
+            int r = flush_write_sector();
+            if (r != RESPONSE_SUCCESS) {
+                s_write_state.sector_buf_filled = 0;
+                return r;
+            }
+        }
+    }
+    return RESPONSE_SUCCESS;
+}
+
+int sdmmc_plugin_write_flash_end(uint8_t command, const uint8_t *data, uint32_t len,
+                                 struct command_response_data *resp)
+{
+    (void)command;
+    (void)resp;
+    if (len != SDMMC_WRITE_FLASH_END_SIZE) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+    if (!s_write_state.in_progress) {
+        return RESPONSE_NOT_IN_FLASH_MODE;
+    }
+    if (s_write_state.total_remaining != 0) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    if (s_write_state.sector_buf_filled > 0) {
+        // Pad partial trailing sector with 0xFF so we program a full block.
+        memset(s_write_state.sector_buf + s_write_state.sector_buf_filled,
+               0xFF, SECTOR_SIZE - s_write_state.sector_buf_filled);
+        s_write_state.sector_buf_filled = SECTOR_SIZE;
+        int r = flush_write_sector();
+        if (r != RESPONSE_SUCCESS) {
+            s_write_state.sector_buf_filled = 0;
+            return r;
+        }
+    }
+    (void)get_le_to_u32(data);  // reboot_flag — no chip-side reboot on SDMMC
+    memset(&s_write_state, 0, sizeof(s_write_state));
+    return RESPONSE_SUCCESS;
+}
+
+int sdmmc_plugin_erase_region(uint8_t command, const uint8_t *data, uint32_t len,
+                              struct command_response_data *resp)
+{
+    (void)command;
+    (void)resp;
+    if (len != SDMMC_ERASE_REGION_SIZE) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    uint32_t start = get_le_to_u32(data + 0);
+    uint32_t size  = get_le_to_u32(data + 4);
+    if ((start % SECTOR_SIZE) != 0 || (size % SECTOR_SIZE) != 0 || size == 0) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+    uint32_t start_lba = start / SECTOR_SIZE;
+    uint32_t end_lba   = start_lba + (size / SECTOR_SIZE) - 1U;
+    return sdmmc_err_to_response(stub_target_sdmmc_erase_range(start_lba, end_lba));
+}
+
+int sdmmc_plugin_get_info(uint8_t command, const uint8_t *data, uint32_t len,
+                          struct command_response_data *resp)
+{
+    (void)command;
+    (void)data;
+    if (len != SDMMC_GET_INFO_SIZE) {
+        return RESPONSE_BAD_DATA_LEN;
+    }
+
+    const stub_target_sdmmc_card_info_t *ci = stub_target_sdmmc_get_card_info();
+    if (ci == NULL) {
+        return RESPONSE_NOT_IN_FLASH_MODE;
+    }
+
+    // Same payload as attach + 16 bytes of CID for host-side identification.
+    resp->value = (uint32_t)(ci->capacity_bytes / SECTOR_SIZE);
+    set_u32_to_le(resp->data + 0, ci->ocr);
+    set_u32_to_le(resp->data + 4, ci->rca);
+    uint32_t flags = (ci->is_mmc ? 1U : 0U) | (ci->is_high_capacity ? 2U : 0U) | ((uint32_t)ci->width << 4);
+    set_u32_to_le(resp->data + 8, flags);
+    for (uint32_t i = 0; i < 4; i++) {
+        set_u32_to_le(resp->data + 12 + i * 4, ci->cid[i]);
+    }
+    resp->data_size = 12 + 16;
+    return RESPONSE_SUCCESS;
+}

--- a/tools/elf2json.py
+++ b/tools/elf2json.py
@@ -33,6 +33,15 @@ PLUGIN_HANDLER_SYMBOLS: Dict[str, Dict[str, str]] = {
         '0xDC': 'nand_plugin_erase_region',
         '0xDD': 'nand_plugin_read_page_debug',
     },
+    'sdmmc': {
+        '0xDF': 'sdmmc_plugin_attach',
+        '0xE0': 'sdmmc_plugin_read_flash',
+        '0xE1': 'sdmmc_plugin_write_flash_begin',
+        '0xE2': 'sdmmc_plugin_write_flash_data',
+        '0xE3': 'sdmmc_plugin_write_flash_end',
+        '0xE4': 'sdmmc_plugin_erase_region',
+        '0xE5': 'sdmmc_plugin_get_info',
+    },
 }
 
 PLUGIN_FIRST_OPCODE = 0xD5


### PR DESCRIPTION
## Description

Adds an "sdmmc" plugin (opcodes 0xDF–0xE5) that programs SD/MMC cards
via the ESP32-S3 SDMMC host peripheral.  The plugin sits alongside the
existing NAND plugin and uses the same FPT dispatch + streaming-read +
chunked-write protocol — the only addressing difference is that SDMMC
is sector-addressed (512 B) instead of NAND-page-addressed.

Opcodes (see docs/plugins/sdmmc.md for the full reference):
```
  0xDF  SDMMC_ATTACH              bring up host + init card, return CID/OCR
  0xE0  SDMMC_READ_FLASH          streaming read with MD5
  0xE1  SDMMC_WRITE_FLASH_BEGIN
  0xE2  SDMMC_WRITE_FLASH_DATA
  0xE3  SDMMC_WRITE_FLASH_END
  0xE4  SDMMC_ERASE_REGION        CMD32/33/38 (SD) or CMD35/36/38 (eMMC)
  0xE5  SDMMC_GET_INFO            attach response + CID
```

Defaults match ESP-IDF v6.0 SDMMC_SLOT_CONFIG_DEFAULT for ESP32-S3
(CLK=14, CMD=15, D0=2, D1=4, D2=12, D3=13, D4=33, D5=34, D6=35, D7=36,
slot 0, 4-bit, 20 MHz).  Host-side support is in the matching esptool
PR.

Bumps esp-stub-lib submodule to pick up the SDMMC HAL.

## Testing

Full disclosure: quick and dirty AI attempt, not heavily tested but appears to be working.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
