### PR TITLE
feat(esp32): enable clock/APB boost on UART transport (ESPTOOL-1351)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,14 @@ add_executable(${TARGET_NAME}
     "transport.c"
 )
 
+# The UART clock/APB boost is verified safe only on ESP32 (its stub_target_clock_init sets DBIAS;
+# the ESP32-S3 UART path is unstable without it). Define ESP32 (same style as the existing ESP8266
+# chip macro) so main.c enables the boost for UART on esp32 only; other targets keep upstream
+# USB-only clock behaviour. The conditional erase and larger flash block are chip-independent.
+if(TARGET_CHIP STREQUAL "esp32")
+    target_compile_definitions(${TARGET_NAME} PRIVATE ESP32)
+endif()
+
 target_link_options(${TARGET_NAME} PRIVATE
     -L${LINKER_SCRIPTS_DIR}
     "-T${CHIP_LINKER_SCRIPT}"

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <esp-stub-lib/flash.h>
 #include <esp-stub-lib/clock.h>
+#include <esp-stub-lib/uart.h>
 #include <esp-stub-lib/usb_otg.h>
 #include "command_handler.h"
 #include "transport.h"
@@ -36,11 +37,25 @@ void esp_main(void)
     const int transport = stub_transport_detect();
 
     // stub_lib_clock_init() increases CPU frequency which benefits both USB and UART transfers.
-    // Currently only enabled for USB transfers due to concerns about instability (observed on ESP32-S3),
-    // because DBIAS voltage not being set. This needs investigation and potentially enabling for all transport types.
-    if (transport == TRANSPORT_USB_OTG || transport == TRANSPORT_USB_SERIAL_JTAG || transport == TRANSPORT_SDIO) {
+    // Upstream enables it only for USB transports: the ESP32-S3 UART path was unstable because
+    // DBIAS was not set. ESP32's stub_target_clock_init() DOES set DBIAS (RTC_CNTL_DBIAS_1V25),
+    // so enabling the boost for UART is verified safe ON ESP32 ONLY. ESP32 is defined
+    // by the build only for TARGET_CHIP=esp32; every other target keeps the upstream USB-only gate.
+#ifdef ESP32
+    stub_lib_clock_init();
+
+    // The boost raises APB to 80 MHz, changing the ROM-set UART baud divider. Reprogram it for the
+    // current ROM link baud (115200) right after the boost, else the OHAI/handshake is corrupted;
+    // esptool then issues its own CHANGE_BAUDRATE (recomputed from the new 80 MHz APB).
+    if (transport == TRANSPORT_UART) {
+        stub_lib_uart_rominit_set_baudrate(UART_NUM_0, 115200);
+    }
+#else
+    if (transport == TRANSPORT_USB_OTG || transport == TRANSPORT_USB_SERIAL_JTAG ||
+            transport == TRANSPORT_SDIO) {
         stub_lib_clock_init();
     }
+#endif
 
     stub_lib_flash_init(NULL);
     stub_lib_flash_attach(0, false);


### PR DESCRIPTION
Hi,

We use this stub to flash ESP32 modules on our production test stand (the module is
flashed over UART, through a built-in CH343 USB-UART bridge), and we tried to understand
where the flashing time goes.

I see that stub_lib_clock_init() (it raises APB 40 -> 80 MHz and makes flash writes
faster) is called only for the USB transports. Over a plain UART the stub stays on the ROM
download clock, so writing to flash is slower than it can be.

As I understand, the boost is disabled for UART because on ESP32-S3 the UART path was not
stable without setting DBIAS. But on ESP32 the target stub_target_clock_init() does set
DBIAS (RTC_CNTL_DBIAS_1V25), so for esp32 the boost over UART should be safe.

So this PR turns the boost on for UART, but only for esp32 - through an ESP32 compile
define that the build sets for TARGET_CHIP=esp32 (same style like the existing ESP8266
macro). All other targets keep the current USB-only behaviour, for them nothing changes.

One important moment: raising APB to 80 MHz changes the ROM baud divider of the UART, so
right after the boost I program the divider again for the current link baud (115200).
Without this the OHAI handshake becomes corrupted.

Testing: measured on ESP32-U4WDH over CH343, write throughput grows about +12..17%. On real
hardware I could test only esp32, other targets are not touched by this change. If you
prefer another way to gate it (for example a per-chip config instead of the macro), please
tell me.
