### PR TITLE
feat: enlarge flash write block to 32 KB (ESPTOOL-1350)

### DIFF
--- a/src/frame_buffer.h
+++ b/src/frame_buffer.h
@@ -14,8 +14,16 @@
 extern "C" {
 #endif
 
-/* Maximum frame size: 8-byte SLIP header + esptool max data payload (WRITE_FLASH uses 0x4000+0xFF). */
-#define FRAME_BUFFER_SIZE (8U + 0x4000U + 0xFFU)
+/* Maximum frame size: 8-byte SLIP header + esptool max data payload + SLIP slack.
+ * Flash block enlarged to 32KB (fewer round-trips); run esptool with FLASH_WRITE_SIZE=0x8000
+ * to match. The double buffer must fit the stub's DRAM window (see the target linker script).
+ * Exception: esp8266's DRAM window is too small for a 2x32KB double buffer, so it stays at
+ * 16KB (FLASH_WRITE_SIZE=0x4000). ESP8266 is a build-time define (-DESP8266, see cmake). */
+#ifdef ESP8266
+#define FRAME_BUFFER_SIZE (8U + 0x4000U + 0xFFU)   /* 16KB: esp8266 DRAM too small for a 2x32KB double buffer */
+#else
+#define FRAME_BUFFER_SIZE (8U + 0x8000U + 0xFFU)   /* 32KB: fewer round-trips */
+#endif
 
 enum frame_buffer_state {
     FRAME_BUFFER_STATE_IDLE,

--- a/src/ld/esp32.ld
+++ b/src/ld/esp32.ld
@@ -3,7 +3,12 @@
    else... */
 MEMORY {
   iram : org = 0x400A8000, len = 0x2100
-  dram : org = 0x3ffcc000, len = 0x14000
+  dram : org = 0x3ffc3000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x3ffe0000 for this chip; the first ROM DRAM global is
+   gpio_pending_mask = 0x3ffe0038 (see esp-stub-lib esp32.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x3ffe0000, "esp32: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32c2.ld
+++ b/src/ld/esp32c2.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x40380000, len = 0x4500
-  dram : org = 0x3FCA4000, len = 0x18000
+  dram : org = 0x3FCA4000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x3fcdfaa4 for this chip (phy_param_rom, see esp-stub-lib esp32c2.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x3fcdfaa4, "esp32c2: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32c3.ld
+++ b/src/ld/esp32c3.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x40380000, len = 0x4500
-  dram : org = 0x3FC84000, len = 0x18000
+  dram : org = 0x3FC84000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x3fcdf834 for this chip (g_coex_param_ptr, see esp-stub-lib esp32c3.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x3fcdf834, "esp32c3: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32c5.ld
+++ b/src/ld/esp32c5.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x40800000, len = 0x4500
-  dram : org = 0x40840000, len = 0x18000
+  dram : org = 0x40840000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x4085ffc8 for this chip (rom_cache_internal_table_ptr, see esp-stub-lib esp32c5.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x4085ffc8, "esp32c5: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32c6.ld
+++ b/src/ld/esp32c6.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x40800000, len = 0x4500
-  dram : org = 0x40840000, len = 0x18000
+  dram : org = 0x40840000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x4087ffc8 for this chip (rom_cache_internal_table_ptr, see esp-stub-lib esp32c6.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x4087ffc8, "esp32c6: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32c61.ld
+++ b/src/ld/esp32c61.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x40800000, len = 0x4500
-  dram : org = 0x40804000, len = 0x18000
+  dram : org = 0x40804000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x4084ffc8 for this chip (rom_cache_internal_table_ptr, see esp-stub-lib esp32c61.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x4084ffc8, "esp32c61: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32h2.ld
+++ b/src/ld/esp32h2.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x40800000, len = 0x4500
-  dram : org = 0x40830000, len = 0x18000
+  dram : org = 0x40830000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x4084ffc8 for this chip (rom_cache_internal_table_ptr, see esp-stub-lib esp32h2.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x4084ffc8, "esp32h2: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32h4.ld
+++ b/src/ld/esp32h4.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x40810000, len = 0x4500
-  dram : org = 0x40830000, len = 0x18000
+  dram : org = 0x40830000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x4085ffc4 for this chip (rom_cache_internal_table_ptr, see esp-stub-lib esp32h4.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x4085ffc4, "esp32h4: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32p4-rev1.ld
+++ b/src/ld/esp32p4-rev1.ld
@@ -1,6 +1,13 @@
 MEMORY {
   iram : org = 0x4FF10000, len = 0x4500
-  dram : org = 0x4FF50000, len = 0x18000
+  dram : org = 0x4FF50000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   esp32p4-rev1 maps to the esp32p4 target. The window sits between the two ROM revisions'
+   pointer blocks: base esp32p4.rom.ld places s_usb_osglue lower at 0x4ff3ffc8 (below org),
+   while esp32p4.rom.eco5.ld places it at 0x4ffbffc8 (above the window top). Guard against the
+   higher (eco5) block. */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x4ffbffc8, "esp32p4-rev1: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32p4.ld
+++ b/src/ld/esp32p4.ld
@@ -1,6 +1,12 @@
 MEMORY {
   iram : org = 0x4FF50000, len = 0x4500
-  dram : org = 0x4FF60000, len = 0x18000
+  dram : org = 0x4FF60000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   The window sits between the two ROM revisions' pointer blocks: base esp32p4.rom.ld places
+   s_usb_osglue lower at 0x4ff3ffc8 (below org), while esp32p4.rom.eco5.ld places it at
+   0x4ffbffc8 (above the window top). Guard against the higher (eco5) block. */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x4ffbffc8, "esp32p4: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld

--- a/src/ld/esp32s2.ld
+++ b/src/ld/esp32s2.ld
@@ -3,4 +3,12 @@ MEMORY {
   dram : org = 0x3FFD0000, len = 0x28000
 }
 
+/* Compile-time guard against overrunning into the ROM download stack.
+   The 0x28000 window is the upstream (espressif) value, kept unchanged. It deliberately spans
+   the ROM shared-buffer scratch region near the top of DRAM (e.g. g_shared_buffers = 0x3ffeab04,
+   just above the _dram0_0_start = 0x3ffeab00 marker), which the stub is free to reuse while it
+   runs. The ceiling 0x3fffc410 is _stack_sentry -- the bottom of the ROM download stack, the real
+   limit the window must not cross (see esp-stub-lib esp32s2.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x3fffc410, "esp32s2: stub DRAM window reaches the ROM download stack")
+
 INCLUDE common.ld

--- a/src/ld/esp32s3.ld
+++ b/src/ld/esp32s3.ld
@@ -3,4 +3,9 @@ MEMORY {
   dram : org = 0x3FCA0000, len = 0x28000
 }
 
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x3fcef81c for this chip (phy_param_rom, see esp-stub-lib esp32s3.rom.ld).
+   The hardware-verified 0x28000 window already fits the 32KB stub and is left unchanged. */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x3fcef81c, "esp32s3: stub DRAM window overlaps ROM data")
+
 INCLUDE common.ld

--- a/src/ld/esp32s31.ld
+++ b/src/ld/esp32s31.ld
@@ -1,6 +1,10 @@
 MEMORY {
   iram : org = 0x2F001000, len = 0x4500
-  dram : org = 0x2F00A000, len = 0x18000
+  dram : org = 0x2F00A000, len = 0x1D000
 }
+
+/* Compile-time guard: keep the stub DRAM window clear of ROM data at the top of DRAM.
+   ROM data begins at 0x2f07ffac for this chip (s_usb_osglue, see esp-stub-lib esp32s31.rom.ld). */
+ASSERT(ORIGIN(dram) + LENGTH(dram) <= 0x2f07ffac, "esp32s31: stub DRAM window overlaps ROM data")
 
 INCLUDE common.ld


### PR DESCRIPTION
Hi,

Third small optimization from our production flashing work.

The idea is simple - raise FRAME_BUFFER_SIZE from 16 KB to 32 KB, so esptool can send bigger
FLASH_DEFL_DATA chunks (with FLASH_WRITE_SIZE=0x8000) and we get two times less per-block
round-trips.

The buffer is a double buffer in .bss (2 x 32 KB), so it needs more DRAM. I enlarged the
DRAM window in the linker script of every chip to fit it (to len 0x1D000, like esp32 already
use). And to be safe I also add a link-time ASSERT to each script - the window must stay
below the ROM data on top of DRAM, so if some window is wrong the build fails instead of
corrupting RAM silently. The ceilings I took from esp-stub-lib rom.ld of each target.

ESP8266 stays on 16 KB: its DRAM (~80 KB) is too small for a 2 x 32 KB double buffer, so
there FRAME_BUFFER_SIZE is kept 16 KB with #ifdef.

Testing: measured on ESP32-U4WDH over CH343, on a real firmware image ~1.13 MB (compressed).
The bigger block halves the round-trips (70 -> 35 blocks), write phase @4M baud:

    block 16 KB (70 round-trips):  15.3 s
    block 32 KB (35 round-trips):  14.9 s

So the block alone gives about +2..4% here, a bit less than half a second on this image. It
is a small win, but it is free and it stacks with the other changes - on our stand 16 KB ->
32 KB together with the UART clock boost goes 15.3 s -> 12.5 s. On very compressible data
(mostly 0xFF / zeros) the write is flash-bound, so there the block size almost does not
change the time.

On real hardware I could verify only esp32 (our module). For all the other targets I only
checked in CI that they build (link) with the new windows. So for the chips I can not test,
please look on the linker windows - the ASSERT guards the ROM data, but the exact numbers
you know better than me, maybe some window you will want to place other way.
