### PR TITLE
ci(size_report): Post size report on fork PRs via workflow_run

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -61,8 +61,13 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     permissions:
-      actions: write   # needed to trigger a master workflow_dispatch when artifacts have expired
-      pull-requests: write
+      # Fork PRs run with a read-only GITHUB_TOKEN, so this job does not post
+      # the comment itself: it uploads the report as an artifact, and the
+      # size_report_comment.yml (workflow_run) receiver posts it with a write
+      # token in base-repo context.  Only actions:write is still needed here,
+      # to download / trigger a master build for the comparison — this works
+      # for same-repo PRs and degrades gracefully to a PR-only report on forks.
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -189,11 +194,11 @@ jobs:
 
           echo "::notice::Could not obtain master artifacts; skipping comparison"
 
-      - name: Generate and post size report
+      - name: Generate size report
         env:
-          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          mkdir -p size-report
           if [ -d master-artifacts ]; then
             REPORT=$(python tools/compare_sizes.py \
               --master-dir master-artifacts \
@@ -203,24 +208,26 @@ jobs:
               --pr-dir pr-artifacts)
           fi
 
+          # First line is the marker used to find/update the comment later.
           MARKER='<!-- stub-size-report -->'
-          BODY="${MARKER}"$'\n'"${REPORT}"
+          {
+            printf '%s\n' "$MARKER"
+            printf '%s\n' "$REPORT"
+          } > size-report/report.md
 
-          # Find existing size-report comment (if any)
-          COMMENT_ID=$(gh api \
-            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
-            | head -n1)
+          # Record the PR number for the workflow_run receiver: for fork PRs the
+          # workflow_run event payload does not carry the PR, so we pass it along
+          # here.  The receiver treats it as untrusted and validates it against
+          # the built commit before commenting.
+          printf '%s\n' "$PR_NUMBER" > size-report/pr-number
 
-          if [ -n "$COMMENT_ID" ]; then
-            gh api \
-              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
-              --method PATCH --field body="$BODY"
-          else
-            gh pr comment "$PR_NUMBER" \
-              --repo "${{ github.repository }}" \
-              --body "$BODY"
-          fi
+      - name: Upload size report
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-report
+          path: size-report/
+          if-no-files-found: error
+          retention-days: 3
 
   create_release:
     name: Create GitHub release

--- a/.github/workflows/size_report_comment.yml
+++ b/.github/workflows/size_report_comment.yml
@@ -1,0 +1,101 @@
+---
+name: Post stub size report
+
+# Fork pull_request runs get a read-only GITHUB_TOKEN and cannot post PR
+# comments, so "Build and release" only *builds* the size report and uploads
+# it as an artifact.  This workflow runs on workflow_run in the base-repo
+# context with a write token and posts the comment.
+#
+# Security: this workflow never checks out or executes any code from the PR
+# head — it only downloads the artifact (opaque data) produced by the build
+# and posts it.  The PR number carried in the artifact is treated as untrusted
+# and validated against the commit that was actually built before commenting.
+on:
+  workflow_run:
+    workflows: ["Build and release"]
+    types: [completed]
+
+permissions:
+  actions: read          # download the size-report artifact from the triggering run
+  pull-requests: write   # create/update the PR comment
+
+jobs:
+  comment:
+    name: Post size report comment
+    # Only act on runs that came from a pull request.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    # Serialize per source branch so two quick pushes cannot race and create
+    # duplicate comments; the marker-based upsert then updates in place.
+    concurrency:
+      group: size-report-comment-${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_branch
+        }}
+      cancel-in-progress: false
+    steps:
+      - name: Download size report artifact
+        id: download
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          # The artifact is absent when the build failed before uploading it
+          # (e.g. build_stubs failed) — that is not an error for this workflow.
+          if gh run download "$RUN_ID" \
+            --repo "$REPO" --name size-report --dir size-report 2>/dev/null; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No size-report artifact on run $RUN_ID; nothing to post"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post or update comment
+        if: steps.download.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |-
+          set -euo pipefail
+
+          REPORT_FILE=size-report/report.md
+          MARKER='<!-- stub-size-report -->'
+
+          # --- Sanitize the PR number carried by the (untrusted) artifact ---
+          PR_NUMBER=$(tr -dc '0-9' < size-report/pr-number || true)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::warning::Missing/empty PR number in artifact; skipping"
+            exit 0
+          fi
+
+          # The PR the report claims to be for must actually be built from the
+          # commit this run built.  This stops a malicious fork from setting an
+          # arbitrary PR number to hijack the comment thread of another PR.
+          PR_HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null || true)
+          if [ -z "$PR_HEAD_SHA" ] || [ "$PR_HEAD_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::warning::PR #$PR_NUMBER head ('$PR_HEAD_SHA') != built commit ('$EXPECTED_SHA'); skipping"
+            exit 0
+          fi
+
+          # The body must start with our marker; bounds arbitrary content from a
+          # fork that modified the report generator.
+          if ! head -n1 "$REPORT_FILE" | grep -qF "$MARKER"; then
+            echo "::warning::Report artifact missing expected marker; skipping"
+            exit 0
+          fi
+          # Cap well under GitHub's 65536-char comment limit.
+          BODY=$(head -c 60000 "$REPORT_FILE")
+
+          # Find the existing size-report comment (if any) and upsert.
+          COMMENT_ID=$(gh api \
+            "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
+            | head -n1 || true)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+              --method PATCH --raw-field body="$BODY"
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --method POST --raw-field body="$BODY"
+          fi

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -102,7 +102,8 @@ Before submitting a pull request:
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| Build and Release | Push, PR | Build firmware for all chips; post stub size report on PRs; create releases on tags |
+| Build and Release | Push, PR | Build firmware for all chips; generate the stub size report on PRs (uploaded as an artifact); create releases on tags |
+| Post stub size report | `workflow_run` after Build and Release | Post/update the size report comment on the PR (runs with a write token so it also works for fork PRs) |
 | Host Tests | Push | Run native unit tests |
 | DangerJS | PR | Validate PR style and conventions |
 | Jira | PR | Sync with Jira issue tracker |


### PR DESCRIPTION
Fork PRs run with a read-only `GITHUB_TOKEN`, so the size-report job fails when it tries to post the PR comment (`Resource not accessible by integration (addComment)`). Recent failures:

- https://github.com/espressif/esp-flasher-stub/actions/runs/28549925525
- https://github.com/espressif/esp-flasher-stub/actions/runs/28549923759
- https://github.com/espressif/esp-flasher-stub/actions/runs/28549442805

This splits the flow into the standard `workflow_run` pattern: **Build and release** only builds the report and uploads it as an artifact; a new **Post stub size report** workflow runs in base-repo context with a write token and posts the comment — so it works for fork PRs too.

⚠️ **Takes effect only after merge:** `workflow_run` fires only from the workflow copy on the default branch, so this cannot be validated on this PR. Verify with a fork PR once merged to `master`.

**Security:** the receiver never checks out or runs PR-head code — it only downloads the artifact (opaque data). The PR number carried in the artifact is untrusted: it is sanitized, and the PR's head SHA must match the commit that was actually built before commenting, preventing a malicious fork from hijacking another PR's comment thread. Permissions are minimal (`actions: read`, `pull-requests: write`) and no untrusted input is interpolated into shell.
