### PR TITLE
feat: skip erase of already-blank sectors in write_flash (ESPTOOL-1349)

### DIFF
--- a/cmake/esp-targets.cmake
+++ b/cmake/esp-targets.cmake
@@ -42,6 +42,7 @@ set(ESP8266_COMPILER_FLAGS
     -DESP8266
     -mlongcalls
     -mtext-section-literals
+    -flto
 )
 
 # RISC-V specific compiler flags

--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -148,13 +148,75 @@ static inline int s_check_memory_in_progress(void)
     return RESPONSE_SUCCESS;
 }
 
+/*
+ * Conditional per-sector erase ("skip erase on already-blank sectors").
+ *
+ * Heuristic: while no dirty sector has been seen yet, read each sector and skip its
+ * erase if it is already all-0xFF (erased/blank). On the FIRST non-blank sector, latch
+ * s_dirty_seen and fall back to unconditional erase for the rest (no more reads) -- a
+ * used chip is dirty from its low addresses (bootloader), so the wasted reads are ~one
+ * sector, while a factory-blank chip skips ALL erases. Correctness is guaranteed: a
+ * sector is only left un-erased when verified blank, and program can write any data
+ * onto blank (0xFF) flash.
+ */
+static bool s_dirty_seen = false;
+
+static int s_sector_is_blank(uint32_t addr, uint32_t sector_size, bool *is_blank)
+{
+    uint32_t buf[1024]; /* one 4 KB sector on the stack, 4-byte aligned by type */
+    *is_blank = true;
+    for (uint32_t off = 0; off < sector_size; off += sizeof(buf)) {
+        uint32_t chunk = MIN(sector_size - off, (uint32_t)sizeof(buf));
+        if (stub_lib_flash_read_buff(addr + off, buf, chunk) != STUB_LIB_OK) {
+            return RESPONSE_FAILED_SPI_OP;
+        }
+        for (uint32_t i = 0; i < chunk / sizeof(buf[0]); i++) {
+            if (buf[i] != 0xFFFFFFFFU) {
+                *is_blank = false;
+                return RESPONSE_SUCCESS;
+            }
+        }
+    }
+    return RESPONSE_SUCCESS;
+}
+
+static int s_conditional_erase_next(void)
+{
+    if (s_flash_state.erase_remaining == 0) {
+        return RESPONSE_SUCCESS;
+    }
+
+    if (!s_dirty_seen) {
+        stub_lib_flash_config_t config;
+        stub_lib_flash_get_config(&config);
+        bool blank = true;
+        int read_result = s_sector_is_blank(s_flash_state.next_erase_addr, config.sector_size, &blank);
+        if (read_result != RESPONSE_SUCCESS) {
+            return read_result;
+        }
+        if (blank) {
+            uint32_t step = MIN(s_flash_state.erase_remaining, config.sector_size);
+            s_flash_state.next_erase_addr += config.sector_size;
+            s_flash_state.erase_remaining -= step;
+            return RESPONSE_SUCCESS;
+        }
+        s_dirty_seen = true; /* from here on erase everything without reading */
+    }
+
+    int result = stub_lib_flash_start_next_erase(&s_flash_state.next_erase_addr,
+                                                 &s_flash_state.erase_remaining, 0);
+    if (result != STUB_LIB_OK && result != STUB_LIB_ERR_TIMEOUT) {
+        return RESPONSE_FAILED_SPI_OP;
+    }
+    return RESPONSE_SUCCESS;
+}
+
 static inline int s_ensure_flash_erased_to(uint32_t target_addr)
 {
     while (s_flash_state.next_erase_addr < target_addr) {
-        int result = stub_lib_flash_start_next_erase(&s_flash_state.next_erase_addr,
-                                                     &s_flash_state.erase_remaining, 0);
-        if (result != STUB_LIB_OK && result != STUB_LIB_ERR_TIMEOUT) {
-            return RESPONSE_FAILED_SPI_OP;
+        int result = s_conditional_erase_next();
+        if (result != RESPONSE_SUCCESS) {
+            return result;
         }
     }
     return RESPONSE_SUCCESS;
@@ -191,11 +253,11 @@ static int s_init_flash_operation(const uint8_t *buffer, uint16_t size, bool is_
     s_flash_state.erase_remaining = erase_end - erase_start;
     s_flash_state.next_erase_addr = erase_start;
 
-    // Start the next erase operation, but do not wait for it to complete
-    int result = stub_lib_flash_start_next_erase(&s_flash_state.next_erase_addr,
-                                                 &s_flash_state.erase_remaining, 0);
-    if (result != STUB_LIB_OK && result != STUB_LIB_ERR_TIMEOUT) {
-        return RESPONSE_FAILED_SPI_OP;
+    // Reset the skip-erase heuristic and start the first (conditional) erase without waiting.
+    s_dirty_seen = false;
+    int result = s_conditional_erase_next();
+    if (result != RESPONSE_SUCCESS) {
+        return result;
     }
 
     return RESPONSE_SUCCESS;
@@ -259,7 +321,9 @@ static int s_flash_defl_data_post_process(const struct cmd_ctx *ctx)
 
     const uint8_t *compressed_data = ctx->data + FLASH_DEFL_DATA_HEADER_SIZE;
 
-    static uint8_t decompressed_data[TINFL_LZ_DICT_SIZE];
+    /* tinfl reads words from this dictionary on ESP8266; keep it aligned even if
+     * preceding static objects change the BSS layout. */
+    static uint8_t decompressed_data[TINFL_LZ_DICT_SIZE] __attribute__((aligned(4)));
     static uint8_t *decompressed_data_ptr = decompressed_data;
 
     /* Ensure decompression buffer state is reset at the start of a new stream */
@@ -279,11 +343,10 @@ static int s_flash_defl_data_post_process(const struct cmd_ctx *ctx)
             flags |= TINFL_FLAG_HAS_MORE_INPUT;
         }
 
-        /* Start opportunistic erase during decompression */
-        int result = stub_lib_flash_start_next_erase(&s_flash_state.next_erase_addr,
-                                                     &s_flash_state.erase_remaining, 0);
-        if (result != STUB_LIB_OK && result != STUB_LIB_ERR_TIMEOUT) {
-            return RESPONSE_FAILED_SPI_OP;
+        /* Opportunistic conditional erase during decompression */
+        int result = s_conditional_erase_next();
+        if (result != RESPONSE_SUCCESS) {
+            return result;
         }
 
         status = tinfl_decompress(&s_flash_state.decompressor,

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,10 @@ __asm__(
     "esp_main_esp8266:\n"
     "movi a0, 0x400010a8;"
     "j esp_main;");
+
+/* esp_main is only referenced from the assembly entry stub above, which is
+ * opaque to LTO; keep it visible so whole-program optimization preserves it. */
+void esp_main(void) __attribute__((used, externally_visible));
 #endif //ESP8266
 
 void esp_main(void)


### PR DESCRIPTION
## Summary

This is a replacement for #85. The implementation is based on vvzvlad's original PR, but maintainers cannot push the refreshed history back to the original fork branch (`wirenboard/wb-esp-flasher-stub:skip-erase-blank-sectors`), so the replacement branch is hosted in this repository instead.

The branch keeps vvzvlad as the author of both feature commits.

## What This PR Does

`write_flash` currently erases the whole target region before programming. On a factory-blank chip, where flash is already all `0xFF`, this erase is redundant.

Before erasing each sector, the stub now reads the sector and skips the erase if the sector is already blank. After the first non-blank sector is found, it stops probing and erases the rest unconditionally, avoiding read overhead on used chips where low flash addresses are normally already dirty.

The PR also enables ESP8266 LTO so the skip-erase feature fits within the existing ESP8266 memory layout. ESP8266 compressed writes need the tinfl output dictionary to stay 4-byte aligned, so the decompression buffer is explicitly aligned to avoid unaligned word reads after BSS layout changes.

## esp-stub-lib Update

The submodule is updated from `591ad27` to `845883b`, current `esp-stub-lib` master at the time of this PR. Commits included since the previous pointer:

- `845883b` Jaroslav Burian: change: Update version to 1.2.0
- `9b4ca83` Jaroslav Burian: Merge pull request #120 from ginkgm/fix/esp32p4-stub-360mhz-usj-safe
- `ef772b3` Jaroslav Burian: Merge pull request #123 from espressif/feat/rom-uart-baudrate-getter
- `d875321` Jaroslav Burian: feat(uart): expose ROM baudrate getter
- `3f8c803` Jaroslav Burian: Merge pull request #122 from Dzarda7/esp8266-allow-lto-builds
- `974b471` vvzvlad: fix(esp8266): allow LTO builds
- `04c2c1d` Michael.B: fix(esp32p4): Align stub DCDC handoff and run CPU at CPLL/2
- `bfbcaca` Jaroslav Burian: Merge pull request #121 from espressif/fix/usb-zlp-flush
- `18225f8` Jaroslav Burian: fix: handle USB full-packet flush termination
- `28e5a8c` Roland Dobai: Merge pull request #119 from espressif/pre-commit-ci-update-config
- `d59da93` pre-commit-ci[bot]: ci: Bump pre-commit hooks
- `da1a0f5` Erhan Kurubas: Merge pull request #118 from espressif/fix/build_error
- `4f277e2` erhankur: fix(cache): variable set but not used error
- `be146e9` Radim Karniš: Merge pull request #117 from espressif/change/remove_experimental_status
- `b6cf306` Radim Karniš: change: Remove experimental status

## Test Plan

- `source ./tools/export_toolchains.sh && ./tools/build_all_chips.sh`
- Previously verified ESP8266 compressed `write-flash` with the aligned tinfl dictionary fix.