### PR TITLE
feat: enable clock/APB boost on UART transport (ESPTOOL-1351)

### DIFF
--- a/cmake/esp-targets.cmake
+++ b/cmake/esp-targets.cmake
@@ -39,7 +39,6 @@ set(XTENSA_COMPILER_FLAGS
 # ESP8266-specific compiler flags
 set(ESP8266_COMPILER_FLAGS
     ${COMMON_COMPILER_FLAGS}
-    -DESP8266
     -mlongcalls
     -mtext-section-literals
     -flto
@@ -74,6 +73,14 @@ function(validate_esp_target TARGET_CHIP)
     endif()
 endfunction()
 
+# Function to get the chip-specific compile definition for target
+function(get_chip_compile_definition TARGET_CHIP OUTPUT_VAR)
+    validate_esp_target(${TARGET_CHIP})
+    string(TOUPPER "${TARGET_CHIP}" CHIP_DEFINE)
+    string(REPLACE "-" "_" CHIP_DEFINE "${CHIP_DEFINE}")
+    set(${OUTPUT_VAR} "-D${CHIP_DEFINE}" PARENT_SCOPE)
+endfunction()
+
 # Function to get toolchain prefix for target
 function(get_esp_toolchain_prefix TARGET_CHIP OUTPUT_VAR)
     validate_esp_target(${TARGET_CHIP})
@@ -90,13 +97,14 @@ endfunction()
 # Function to get all compiler flags for target
 function(get_compiler_flags_for_target TARGET_CHIP OUTPUT_VAR)
     validate_esp_target(${TARGET_CHIP})
+    get_chip_compile_definition(${TARGET_CHIP} CHIP_COMPILE_DEFINITION)
 
     if(TARGET_CHIP STREQUAL "esp8266")
-        set(${OUTPUT_VAR} ${ESP8266_COMPILER_FLAGS} PARENT_SCOPE)
+        set(${OUTPUT_VAR} ${ESP8266_COMPILER_FLAGS} ${CHIP_COMPILE_DEFINITION} PARENT_SCOPE)
     elseif(TARGET_CHIP IN_LIST XTENSA_TARGETS)
-        set(${OUTPUT_VAR} ${XTENSA_COMPILER_FLAGS} PARENT_SCOPE)
+        set(${OUTPUT_VAR} ${XTENSA_COMPILER_FLAGS} ${CHIP_COMPILE_DEFINITION} PARENT_SCOPE)
     elseif(TARGET_CHIP IN_LIST RISCV_TARGETS)
-        set(${OUTPUT_VAR} ${RISCV_COMPILER_FLAGS} PARENT_SCOPE)
+        set(${OUTPUT_VAR} ${RISCV_COMPILER_FLAGS} ${CHIP_COMPILE_DEFINITION} PARENT_SCOPE)
     else()
         message(FATAL_ERROR "Unknown target chip: ${TARGET_CHIP}")
     endif()

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,6 @@ void esp_main(void)
 #endif
 
     stub_lib_flash_init(NULL);
-    stub_lib_flash_attach(0, false);
     const struct stub_transport_ops *ops = stub_transport_init(transport);
 
     // Send OHAI greeting to signal stub is active

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <esp-stub-lib/flash.h>
 #include <esp-stub-lib/clock.h>
+#include <esp-stub-lib/uart.h>
 #include <esp-stub-lib/usb_otg.h>
 #include "command_handler.h"
 #include "transport.h"
@@ -39,12 +40,26 @@ void esp_main(void)
 
     const int transport = stub_transport_detect();
 
-    // stub_lib_clock_init() increases CPU frequency which benefits both USB and UART transfers.
-    // Currently only enabled for USB transfers due to concerns about instability (observed on ESP32-S3),
-    // because DBIAS voltage not being set. This needs investigation and potentially enabling for all transport types.
+// UART clock boost is limited to chips with safe DBIAS handling. ESP32 and
+// ESP32-S2 set DBIAS in their target clock init; ESP32-P4 has DBIAS solved.
+// Other chips, notably ESP32-S3, stay on the USB/SDIO-only clock path for now.
+#if defined(ESP32) || defined(ESP32S2) || defined(ESP32P4) || defined(ESP32P4_REV1)
+    uint32_t rom_baudrate = stub_lib_uart_rominit_get_baudrate();
+    if (rom_baudrate == 0) {
+        // ROM download mode defaults to 115200 baud.
+        rom_baudrate = 115200;
+    }
+
+    stub_lib_clock_init();
+
+    // The boost changes the UART source clock. Reprogram the divider for the
+    // ROM link baud, else UART logging and the OHAI/handshake are corrupted.
+    stub_lib_uart_rominit_set_baudrate(UART_NUM_0, rom_baudrate);
+#else
     if (transport == TRANSPORT_USB_OTG || transport == TRANSPORT_USB_SERIAL_JTAG || transport == TRANSPORT_SDIO) {
         stub_lib_clock_init();
     }
+#endif
 
     stub_lib_flash_init(NULL);
     stub_lib_flash_attach(0, false);


### PR DESCRIPTION
## Summary

This is a replacement for #84. The implementation is based on vvzvlad's original PR, but maintainers cannot push the review updates back to the original fork branch (`wirenboard/wb-esp-flasher-stub:esp32-uart-clock-boost`), so the replacement branch is hosted in this repository instead.

The branch keeps vvzvlad as the author of the original feature commit and adds the requested maintainer follow-ups.

## What This PR Does

`stub_lib_clock_init()` raises the CPU/APB clocks, which improves transport throughput. The stub previously only used that boost for USB/SDIO transports because ESP32-S3 UART was unstable without DBIAS handling.

This PR enables the clock boost for UART on chips whose target clock init is known stable for that path:

- ESP32 and ESP32-S2, whose target clock init sets DBIAS.
- ESP32-P4 and ESP32-P4 rev1, where DBIAS handling is solved.

Other targets keep the existing USB/SDIO-only clock-init gate.

For the enabled chips, startup reads the active ROM download-mode baud rate through `stub_lib_uart_rominit_get_baudrate()`, falls back to the ROM default 115200 baud if ROM reports 0, boosts the clock, and then reprograms UART0 to that baud. This keeps UART logging and the OHAI handshake at the expected baud after the clock change.

## esp-stub-lib Updates

This PR bumps `esp-stub-lib` to include:

- [espressif/esp-stub-lib#123](https://github.com/espressif/esp-stub-lib/pull/123) — `stub_lib_uart_rominit_get_baudrate()` for UART baud restore after clock boost.
- [espressif/esp-stub-lib#124](https://github.com/espressif/esp-stub-lib/pull/124) — ESP32-P4 CPLL root mux select after divider setup. ROM download often leaves HP root on XTAL after hard reset; without switching `HP_ROOT_CLK_SRC_SEL` to CPLL (matching IDF order: dividers first, mux last), the CPLL/2 path was ineffective and USJ flash throughput regressed. Merged fix restores ~1600 kbit/s class performance.

## Flash Attach Fix

The stub startup now preserves the flash attach performed by `stub_lib_flash_init(NULL)`. That initialization already uses each target's eFuse-derived SPI pad configuration where available, including ESP32 via `esp_rom_efuse_get_flash_gpio_info()`.

Previously startup immediately called `stub_lib_flash_attach(0, false)` afterwards, which re-attached with default SPI flash routing and could break ESP32 chips with custom SPI flash pads burned in eFuse. Removing the redundant second attach keeps the eFuse-based routing active.

## Review Follow-up

Dzarda7's suggestion from #84 is applied by moving generic chip compile-definition generation into `cmake/esp-targets.cmake`. The build now derives per-chip macros such as `ESP32`, `ESP32S2`, and `ESP32P4_REV1` from `TARGET_CHIP` instead of adding one-off target definitions in `src/CMakeLists.txt`.

## Test Plan

- [x] esp-stub-lib#123 and #124 available via submodule bump
- [ ] `cmake -G Ninja -B build-esp32 -DTARGET_CHIP=esp32 --fresh -Wno-dev && ninja -C build-esp32`
- [ ] `cmake -G Ninja -B build-esp32s2 -DTARGET_CHIP=esp32s2 --fresh -Wno-dev && ninja -C build-esp32s2`
- [ ] `cmake -G Ninja -B build-esp32p4 -DTARGET_CHIP=esp32p4 --fresh -Wno-dev && ninja -C build-esp32p4`
- [ ] `cmake -G Ninja -B build-esp32p4-rev1 -DTARGET_CHIP=esp32p4-rev1 --fresh -Wno-dev && ninja -C build-esp32p4-rev1`
- [ ] ESP32 hardware smoke: load built `esp32.json` via esptool and run `flash-id`
- [x] ESP32-P4 USJ: hard-reset, write-flash; confirm ~1600 kbit/s after CPLL mux fix (was ~900–1200 without mux)