### PR TITLE
feat(esp32s31): enable flasher stub support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project has replaced the deprecated [legacy flasher stub of esptool](https:
 | Architecture | Chips |
 |---|---|
 | Xtensa | ESP32, ESP32-S2, ESP32-S3 |
-| RISC-V | ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-H4, ESP32-P4, ESP32-P4 (rev1) |
+| RISC-V | ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-H4, ESP32-P4, ESP32-P4 (rev1), ESP32-S31 |
 | Xtensa (LX106) | ESP8266 |
 
 ## Obtaining Pre-built Stub JSON Files

--- a/src/main.c
+++ b/src/main.c
@@ -40,10 +40,11 @@ void esp_main(void)
 
     const int transport = stub_transport_detect();
 
-// UART clock boost is limited to chips with safe DBIAS handling. ESP32 and
-// ESP32-S2 set DBIAS in their target clock init; ESP32-P4 has DBIAS solved.
-// Other chips, notably ESP32-S3, stay on the USB/SDIO-only clock path for now.
-#if defined(ESP32) || defined(ESP32S2) || defined(ESP32P4) || defined(ESP32P4_REV1)
+// UART clock boost is limited to chips with safe DBIAS handling. ESP32,
+// ESP32-S2, and ESP32-S31 set DBIAS in their target clock init; ESP32-P4 has
+// DBIAS solved. Other chips, notably ESP32-S3, stay on the USB/SDIO-only clock
+// path for now.
+#if defined(ESP32) || defined(ESP32S2) || defined(ESP32P4) || defined(ESP32P4_REV1) || defined(ESP32S31)
     uint32_t rom_baudrate = stub_lib_uart_rominit_get_baudrate();
     if (rom_baudrate == 0) {
         // ROM download mode defaults to 115200 baud.


### PR DESCRIPTION
## Summary
- add ESP32-S31 to the documented supported targets
- enable UART clock initialization for ESP32-S31
- update esp-stub-lib with S31 clock setup, 4-byte flash addressing, and current master fixes

## esp-stub-lib commits
- `7aa6d33` Merge pull request #126 from espressif/fix/esp32-hspi-strap-flash-attach
- `2337bd5` refactor(flash): exclude 4-byte addressing on unsupported targets
- `1cf16d9` Merge pull request #127 from espressif/split_large_flash_path
- `06111ee` fix(esp32): initialize CPU clock for all revisions
- `e02538c` Merge pull request #129 from espressif/fix/esp32-clock-init
- `4c3f065` feat(esp32s31): initialize CPU clock at 240 MHz
- `8af8dc5` feat(esp32s31): support 4-byte flash addressing
- `542aa89` Merge pull request #130 from Dzarda7/feat/esp32s31-clock-flash

## Test plan
- [x] Build the ESP32-S31 stub and generate `esp32s31.json`
- [x] Load and communicate with the stub over UART
- [x] Verify normal flash write, read, and erase operations
- [x] Exercise forced 4-byte flash read and erase commands on attached hardware