### PR TITLE
fix(esp32p4): bump esp-stub-lib to skip ROM flash XPD when PMU latch is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.2.2 (2026-08-19)
+
+### 🐛 Bug Fixes
+
+- **esp32p4**: bump esp-stub-lib to skip ROM flash XPD when PMU latch is set *(Jaroslav Burian - 11672eb)*
+
+
 ## v1.2.1 (2026-08-07)
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@
 
 [tool.commitizen]
     name = "czespressif"
-    version = "1.2.1"
+    version = "1.2.2"
     update_changelog_on_bump = true
     tag_format = "v$version"
     changelog_start_rev = "v0.0.1"


### PR DESCRIPTION
Updates `esp-stub-lib` from `b8f78b2` to latest master `d61983f` and bumps the version to 1.2.2.

### Commits pulled in from esp-stub-lib

- `974ee4a` fix(esp32s31): add missing memory caps — adds the missing entries to `src/target/esp32s31/include/soc/soc_caps.h`.
- `5e3d512` fix(esp32p4): skip ROM flash XPD when PMU latch is already set — ROM `spi_flash_attach()` ramps flash power when `DOWNLOAD_MODE_XPD_ON` is burned; that sequence must not run again while `PMU_DATE[1:0]` still force the rail on, so it now skips to `boot_attach` in that case.