### PR TITLE
fix(usb_serial_jtag): Flush TX before a frame can end on a full packet

### DIFF
--- a/src/slip.c
+++ b/src/slip.c
@@ -32,6 +32,11 @@ static volatile size_t s_rx_cap;
 static uint8_t (*s_tx_one_char)(uint8_t) = stub_lib_uart_tx_one_char;
 static void (*s_flush_fn)(void) = NULL;
 
+/* Bytes written since the last flush, and the limit that forces an early one.
+ * Zero disables the limit, leaving the end-of-frame flush as the only one. */
+static size_t s_flush_interval;
+static size_t s_unflushed;
+
 void slip_set_tx_fn(uint8_t (*tx_fn)(uint8_t))
 {
     if (tx_fn) {
@@ -44,10 +49,32 @@ void slip_set_flush_fn(void (*flush_fn)(void))
     s_flush_fn = flush_fn;
 }
 
+void slip_set_flush_interval(size_t bytes)
+{
+    s_flush_interval = bytes;
+    s_unflushed = 0;
+}
+
 static void slip_flush(void)
 {
+    s_unflushed = 0;
     if (s_flush_fn) {
         s_flush_fn();
+    }
+}
+
+/*
+ * Send one raw byte, flushing early once s_flush_interval bytes have piled up
+ * since the last flush. See slip_set_flush_interval() for why that matters.
+ */
+static void send_byte(uint8_t byte)
+{
+    s_tx_one_char(byte);
+    if (s_flush_interval != 0) {
+        s_unflushed++;
+        if (s_unflushed >= s_flush_interval) {
+            slip_flush();
+        }
     }
 }
 
@@ -55,15 +82,15 @@ static void send_escaped_byte(uint8_t byte)
 {
     switch (byte) {
     case SLIP_END:
-        s_tx_one_char(SLIP_ESC);
-        s_tx_one_char(SLIP_ESC_END);
+        send_byte(SLIP_ESC);
+        send_byte(SLIP_ESC_END);
         break;
     case SLIP_ESC:
-        s_tx_one_char(SLIP_ESC);
-        s_tx_one_char(SLIP_ESC_ESC);
+        send_byte(SLIP_ESC);
+        send_byte(SLIP_ESC_ESC);
         break;
     default:
-        s_tx_one_char(byte);
+        send_byte(byte);
         break;
     }
 }
@@ -73,12 +100,12 @@ bool slip_send_frame(const void *data, size_t size)
     if (!data) {
         return false;
     }
-    s_tx_one_char(SLIP_END);
+    send_byte(SLIP_END);
     const uint8_t *buf = (const uint8_t *)data;
     for (size_t i = 0; i < size; i++) {
         send_escaped_byte(buf[i]);
     }
-    s_tx_one_char(SLIP_END);
+    send_byte(SLIP_END);
     slip_flush();
     return true;
 }

--- a/src/slip.h
+++ b/src/slip.h
@@ -22,13 +22,37 @@ extern "C" {
 void slip_set_tx_fn(uint8_t (*tx_fn)(uint8_t));
 
 /**
- * @brief Register flush function called after a complete frame is sent
+ * @brief Register flush function called at the end of every frame
  *
  * Optional — pass NULL for transports that do not need explicit flushing.
+ * Called mid-frame as well, whenever slip_set_flush_interval() is in effect
+ * and that many bytes have piled up since the last flush.
  *
  * @param flush_fn Function pointer with signature: void (*)(void)
  */
 void slip_set_flush_fn(void (*flush_fn)(void));
+
+/**
+ * @brief Force a TX flush every @p bytes bytes, on top of the end-of-frame one
+ *
+ * The USB-Serial/JTAG IN endpoint sends a packet on its own as soon as its
+ * 64-byte FIFO fills, so a frame whose wire length is an exact multiple of 64
+ * ends on a full-size packet. USB treats a full-size packet as "more to come",
+ * so the host driver holds those last 64 bytes waiting for a short packet that
+ * never arrives, while the stub waits for the acknowledgement the host cannot
+ * send.
+ *
+ * stub_lib_usb_serial_jtag_tx_flush() recovers from that after the fact: it
+ * waits for the FIFO to become writable so that WR_DONE emits a zero-length
+ * packet, which terminates the transfer. That wait gives up after 50 ms, and a
+ * WR_DONE issued before the FIFO is writable is a no-op, so the recovery can
+ * fail silently. Flushing before the FIFO can fill keeps every packet short,
+ * so no transfer needs terminating and the frame no longer depends on the
+ * zero-length packet.
+ *
+ * @param bytes Maximum bytes between flushes; 0 disables early flushing
+ */
+void slip_set_flush_interval(size_t bytes);
 
 /**
  * @brief Send a SLIP-encoded frame

--- a/src/transport.c
+++ b/src/transport.c
@@ -20,6 +20,11 @@
 #define USB_INTERRUPT_SOURCE  17
 #define UART_INTERRUPT_SOURCE 5
 
+/* Size of the USB-Serial/JTAG IN endpoint FIFO, which is also the endpoint's
+ * max packet size. Staying one byte below it keeps every packet short — see
+ * slip_set_flush_interval() for what a full-size final packet costs us. */
+#define USB_SERIAL_JTAG_PACKET_SIZE 64
+
 /* ---- Interrupt handlers -------------------------------------------------- */
 
 void uart_rx_interrupt_handler()
@@ -165,6 +170,7 @@ const struct stub_transport_ops *stub_transport_init(int transport)
         stub_lib_usb_otg_rominit_intr_attach(USB_INTERRUPT_SOURCE, slip_recv_byte);
         slip_set_tx_fn(stub_lib_usb_otg_tx_one_char);
         slip_set_flush_fn(stub_lib_usb_otg_tx_flush);
+        slip_set_flush_interval(0);
         slip_do_rearm();
         return &s_slip_ops;
 
@@ -175,6 +181,7 @@ const struct stub_transport_ops *stub_transport_init(int transport)
                                                      USB_SERIAL_JTAG_OUT_RECV_PKT_INT_ENA);
         slip_set_tx_fn(stub_lib_usb_serial_jtag_tx_one_char);
         slip_set_flush_fn(stub_lib_usb_serial_jtag_tx_flush);
+        slip_set_flush_interval(USB_SERIAL_JTAG_PACKET_SIZE - 1);
         slip_do_rearm();
         return &s_slip_ops;
 
@@ -195,6 +202,7 @@ const struct stub_transport_ops *stub_transport_init(int transport)
                                           UART_INTR_RXFIFO_FULL | UART_INTR_RXFIFO_TOUT);
         slip_set_tx_fn(stub_lib_uart_tx_one_char);
         slip_set_flush_fn(NULL);
+        slip_set_flush_interval(0);
         slip_do_rearm();
         return &s_slip_ops;
     }

--- a/unittests/host/TestSlip.c
+++ b/unittests/host/TestSlip.c
@@ -25,6 +25,12 @@ void setUp(void)
 
 void tearDown(void)
 {
+    /* The flush-interval tests swap the global TX hooks; put them back so the
+     * order of RUN_TEST() calls cannot change what the other tests exercise. */
+    slip_set_tx_fn(stub_lib_uart_tx_one_char);
+    slip_set_flush_fn(NULL);
+    slip_set_flush_interval(0);
+
     mock_rom_wrappers_Verify();
     mock_rom_wrappers_Destroy();
     mock_uart_Verify();
@@ -54,6 +60,143 @@ void test_slip_send_frame_null_data(void)
 {
     /* No bytes should be sent; function must return false */
     TEST_ASSERT_FALSE(slip_send_frame(NULL, 10));
+}
+
+/* ---- TX: early flushing (slip_set_flush_interval) ------------------------ */
+/*
+ * On USB-Serial/JTAG a flush cannot terminate a transfer once the endpoint
+ * FIFO has drained, so a frame must never end on a full-size packet. These
+ * tests treat the byte counts between flushes as the packets that reach the
+ * host and check that none of them is full-size.
+ */
+
+#define TEST_PACKET_SIZE  64
+#define MAX_FLUSH_POINTS  512
+
+static size_t s_tx_count;
+static size_t s_flush_points[MAX_FLUSH_POINTS];
+static size_t s_flush_count;
+
+static uint8_t counting_tx_one_char(uint8_t c)
+{
+    (void)c;
+    s_tx_count++;
+    return 0;
+}
+
+static void recording_flush(void)
+{
+    if (s_flush_count < MAX_FLUSH_POINTS) {
+        s_flush_points[s_flush_count] = s_tx_count;
+    }
+    s_flush_count++;
+}
+
+static void start_recording(size_t flush_interval)
+{
+    s_tx_count = 0;
+    s_flush_count = 0;
+    memset(s_flush_points, 0, sizeof(s_flush_points));
+    slip_set_tx_fn(counting_tx_one_char);
+    slip_set_flush_fn(recording_flush);
+    slip_set_flush_interval(flush_interval);
+}
+
+/* Longest run of bytes handed to the transport between two flushes, including
+ * any bytes left after the last one. This is the largest packet the host sees. */
+static size_t longest_run(void)
+{
+    TEST_ASSERT_LESS_OR_EQUAL_size_t(MAX_FLUSH_POINTS, s_flush_count);
+
+    size_t longest = 0;
+    size_t prev = 0;
+    for (size_t i = 0; i < s_flush_count; i++) {
+        size_t run = s_flush_points[i] - prev;
+        if (run > longest) {
+            longest = run;
+        }
+        prev = s_flush_points[i];
+    }
+    size_t tail = s_tx_count - prev;
+    return tail > longest ? tail : longest;
+}
+
+void test_slip_flush_interval_disabled_flushes_once_per_frame(void)
+{
+    uint8_t payload[200] = {0};
+
+    start_recording(0);
+    TEST_ASSERT_TRUE(slip_send_frame(payload, sizeof(payload)));
+
+    /* One flush, at the end of the frame, and no early ones */
+    TEST_ASSERT_EQUAL_size_t(1, s_flush_count);
+    TEST_ASSERT_EQUAL_size_t(sizeof(payload) + 2, s_flush_points[0]);
+}
+
+void test_slip_flush_interval_disabled_can_end_on_full_packet(void)
+{
+    /* 62 payload bytes with nothing to escape make a 64-byte frame — the shape
+     * that hangs a USB-Serial/JTAG read. Recorded here as the behaviour the
+     * interval exists to prevent. */
+    uint8_t payload[62] = {0};
+
+    start_recording(0);
+    TEST_ASSERT_TRUE(slip_send_frame(payload, sizeof(payload)));
+
+    TEST_ASSERT_EQUAL_size_t(TEST_PACKET_SIZE, s_tx_count);
+    TEST_ASSERT_EQUAL_size_t(TEST_PACKET_SIZE, longest_run());
+}
+
+void test_slip_flush_interval_never_ends_frame_on_full_packet(void)
+{
+    /* Sweep every payload length, so every frame length modulo the packet size
+     * is covered, including the multiples that trigger the hang. */
+    for (size_t size = 1; size <= 300; size++) {
+        uint8_t payload[300] = {0};
+
+        start_recording(TEST_PACKET_SIZE - 1);
+        TEST_ASSERT_TRUE(slip_send_frame(payload, size));
+
+        TEST_ASSERT_EQUAL_size_t(size + 2, s_tx_count);
+        TEST_ASSERT_LESS_THAN_size_t(TEST_PACKET_SIZE, longest_run());
+    }
+}
+
+void test_slip_flush_interval_counts_escaped_bytes(void)
+{
+    /* Escaping doubles bytes on the wire; the interval must count what is sent,
+     * not what the caller passed in. */
+    uint8_t payload[100];
+    memset(payload, 0xC0, sizeof(payload));
+
+    start_recording(TEST_PACKET_SIZE - 1);
+    TEST_ASSERT_TRUE(slip_send_frame(payload, sizeof(payload)));
+
+    TEST_ASSERT_EQUAL_size_t(2 * sizeof(payload) + 2, s_tx_count);
+    TEST_ASSERT_LESS_THAN_size_t(TEST_PACKET_SIZE, longest_run());
+}
+
+void test_slip_flush_interval_read_flash_block(void)
+{
+    /* The shape reported in espressif/esptool#1184: a 4096-byte read-flash
+     * block holding 62 bytes that need escaping, so the frame is 4160 bytes on
+     * the wire — 65 whole packets. Reading that block over USB-Serial/JTAG hung
+     * every time until the frame stopped ending on a full-size packet. */
+    static uint8_t payload[4096];
+    const size_t escaped_bytes = 62;
+
+    memset(payload, 0x00, sizeof(payload));
+    for (size_t i = 0; i < escaped_bytes; i++) {
+        payload[i] = 0xC0;
+    }
+    const size_t wire_size = sizeof(payload) + escaped_bytes + 2;
+    TEST_ASSERT_EQUAL_size_t(0, wire_size % TEST_PACKET_SIZE);
+
+    start_recording(TEST_PACKET_SIZE - 1);
+    TEST_ASSERT_TRUE(slip_send_frame(payload, sizeof(payload)));
+
+    TEST_ASSERT_EQUAL_size_t(wire_size, s_tx_count);
+    TEST_ASSERT_LESS_THAN_size_t(TEST_PACKET_SIZE, longest_run());
 }
 
 /* ---- RX: slip_recv_byte + frame_buffer ----------------------------------- */
@@ -146,6 +289,11 @@ int main(void)
 
     RUN_TEST(test_slip_send_frame_complete);
     RUN_TEST(test_slip_send_frame_null_data);
+    RUN_TEST(test_slip_flush_interval_disabled_flushes_once_per_frame);
+    RUN_TEST(test_slip_flush_interval_disabled_can_end_on_full_packet);
+    RUN_TEST(test_slip_flush_interval_never_ends_frame_on_full_packet);
+    RUN_TEST(test_slip_flush_interval_counts_escaped_bytes);
+    RUN_TEST(test_slip_flush_interval_read_flash_block);
     RUN_TEST(test_slip_recv_byte_no_frame_start);
     RUN_TEST(test_slip_recv_byte_empty_frame_discarded);
     RUN_TEST(test_slip_recv_byte_complete_frame);


### PR DESCRIPTION
## Description

Fixes the read failures reported in espressif/esptool#1184. `read-flash` aborts with `Packet content transfer stopped` at offsets that differ between devices but repeat exactly for the same flash contents, because SLIP escaping makes the wire length of a frame depend on the data being read.

`slip_set_flush_interval()` documents the mechanism. What it does not say is how this relates to esp-stub-lib `18225f8`, which made `tx_flush()` wait for `SERIAL_IN_EP_DATA_FREE` so that `WR_DONE` emits a ZLP. That resolves the same deadlock after the fact, by terminating a transfer that has already ended on a full-size packet. This change stops the stub from producing such a packet at all, so termination no longer depends on the ZLP being emitted.

## Related

espressif/esptool#1184

## Testing

ESP32-C6FH4 rev v0.2, USB-Serial/JTAG, 4 MB flash.

Reproduced by writing 64 sectors that each hold exactly 62 `0xC0` bytes, which makes every `read-flash` data frame 4160 bytes long (64 x 65), then reading that region back.

`18225f8` already masks the failure on this chip, so it was reverted locally to test this change on its own:

| esp-stub-lib ZLP | this PR | crafted 256 KB read |
|---|---|---|
| on | no | pass |
| on | yes | pass |
| off | no | fail (2/2) |
| off | yes | pass (3/3), data verified |

A full 4 MB read passes with the change applied.
